### PR TITLE
Fix missing Mercado Pago token error

### DIFF
--- a/services/pdf_service.py
+++ b/services/pdf_service.py
@@ -3997,17 +3997,28 @@ def caminho_absoluto_arquivo(imagem_relativa):
 
 import mercadopago
 import os
+import logging
+
+# Configuração do logger para mensagens de pagamento
+payment_logger = logging.getLogger("payment")
 
 token = os.getenv("MERCADOPAGO_ACCESS_TOKEN")
 if not token:
-    raise RuntimeError(
-        "❌ MERCADOPAGO_ACCESS_TOKEN não definido. "
-        "Exporte a variável de ambiente antes de iniciar o servidor."
+    payment_logger.warning(
+        "⚠️ MERCADOPAGO_ACCESS_TOKEN não definido. "
+        "Funções de pagamento estarão desativadas."
     )
-
-sdk = mercadopago.SDK(token)
+    sdk = None
+else:
+    sdk = mercadopago.SDK(token)
 
 def criar_preferencia_pagamento(nome, email, descricao, valor, return_url):
+    if sdk is None:
+        payment_logger.warning(
+            "Tentativa de criar preferência de pagamento com SDK não inicializado"
+        )
+        return None
+
     preference_data = {
         "payer": {"name": nome, "email": email, "last_name": nome},
         "items": [{
@@ -4025,12 +4036,20 @@ def criar_preferencia_pagamento(nome, email, descricao, valor, return_url):
         },
         "auto_return": "approved"
     }
-    preference_response = sdk.preference().create(preference_data)
-    return preference_response["response"]["init_point"]
+    try:
+        preference_response = sdk.preference().create(preference_data)
+        return preference_response["response"]["init_point"]
+    except Exception as e:
+        payment_logger.error(f"Erro ao criar preferência de pagamento: {e}")
+        return None
 
 # utils.py ou dentro da mesma função
 def criar_preference_mp(usuario, tipo_inscricao, evento):
-    sdk = mercadopago.SDK(os.getenv("MERCADOPAGO_ACCESS_TOKEN"))
+    if sdk is None:
+        payment_logger.warning(
+            f"Tentativa de criar preferência MP para usuário {usuario.id} sem SDK inicializado"
+        )
+        return None
 
     valor_com_taxa = float(preco_com_taxa(tipo_inscricao.preco))
 
@@ -4054,8 +4073,12 @@ def criar_preference_mp(usuario, tipo_inscricao, evento):
         "auto_return": "approved",
         "notification_url": url_for("routes.webhook_mp", _external=True)
     }
-    pref = sdk.preference().create(preference_data)
-    return pref["response"]["init_point"]
+    try:
+        pref = sdk.preference().create(preference_data)
+        return pref["response"]["init_point"]
+    except Exception as e:
+        payment_logger.error(f"Erro ao criar preferência MP: {e}")
+        return None
 
 
 # utils.py  (ou um novo arquivo helpers.py)


### PR DESCRIPTION
## Summary
- handle missing `MERCADOPAGO_ACCESS_TOKEN` gracefully
- log warnings when Mercado Pago isn't configured
- guard payment preference helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68463f5123e4833289c3b9b2b4b04dc5