### PR TITLE
Fix login view references

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,7 +30,7 @@ def create_app():
     mail.init_app(app)
     CORS(app)
 
-    login_manager.login_view = "routes.login"
+    login_manager.login_view = "auth_routes.login"
     login_manager.session_protection = "strong"
 
     # Filtros Jinja2

--- a/routes/mercadopago_routes.py
+++ b/routes/mercadopago_routes.py
@@ -33,13 +33,13 @@ def pagamento_sucesso():
 @mercadopago_routes.route("/pagamento_pendente")
 def pagamento_pendente():
     flash("Pagamento pendente. Você poderá concluir mais tarde.", "warning")
-    return redirect(url_for("routes.login"))
+    return redirect(url_for("auth_routes.login"))
 
 
 @mercadopago_routes.route("/pagamento_falha")
 def pagamento_falha():
     flash("Pagamento não foi concluído. Tente novamente.", "danger")
-    return redirect(url_for("routes.login"))
+    return redirect(url_for("auth_routes.login"))
 
 
 @mercadopago_routes.route("/webhook_mp", methods=["POST"])


### PR DESCRIPTION
## Summary
- update Flask-Login configuration to use the correct login blueprint
- adjust MercadoPago routes to redirect to the proper login page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849b4f3f3c083329cf7ef3c9299ef92