### PR TITLE
Fix NameError in cliente routes

### DIFF
--- a/routes/cliente_routes.py
+++ b/routes/cliente_routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template, request, redirect, url_for, flash, abort
+from flask import Blueprint, render_template, request, redirect, url_for, flash, abort, session
 from flask_login import login_required, current_user
 from werkzeug.security import generate_password_hash
 from extensions import db


### PR DESCRIPTION
## Summary
- include `session` import in `cliente_routes.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849b5dce1c8833298a998b38a9bad84