### PR TITLE
Fix template path for participant form

### DIFF
--- a/routes/formularios_routes.py
+++ b/routes/formularios_routes.py
@@ -212,7 +212,7 @@ def preencher_formulario(formulario_id):
         flash("Formulário enviado com sucesso!", "success")
         return redirect(url_for('dashboard_participante_routes.dashboard_participante'))
 
-    return render_template('preencher_formulario.html', formulario=formulario)
+    return render_template('inscricao/preencher_formulario.html', formulario=formulario)
 
 
 @formularios_routes.route('/formularios_participante', methods=['GET'])


### PR DESCRIPTION
## Summary
- fix path to `preencher_formulario` template under `inscricao`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_684a1d16a2b483328bdde0bd5f1d25cf