### PR TITLE
Fix template paths for checkin pages

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -2960,7 +2960,7 @@ def confirmar_checkin_agendamento(token):
             flash(f'Erro ao processar check-in: {str(e)}', 'danger')
     
     # Renderiza a página de confirmação
-    return render_template('confirmar_checkin.html', 
+    return render_template('checkin/confirmar_checkin.html',
                           agendamento=agendamento,
                           evento=evento,
                           horario=horario)

--- a/routes/checkin_routes.py
+++ b/routes/checkin_routes.py
@@ -189,7 +189,7 @@ def checkin(oficina_id):
         return redirect(url_for('dashboard_participante_routes.dashboard_participante'))
 
     opcoes = oficina.opcoes_checkin.split(',') if oficina.opcoes_checkin else []
-    return render_template('checkin.html', oficina=oficina, opcoes=opcoes)
+    return render_template('checkin/checkin.html', oficina=oficina, opcoes=opcoes)
 
 
 
@@ -451,7 +451,7 @@ def confirmar_checkin(agendamento_id):
             flash(f'Erro ao realizar check-in: {str(e)}', 'danger')
     
     return render_template(
-        'confirmar_checkin.html',
+        'checkin/confirmar_checkin.html',
         agendamento=agendamento,
         horario=agendamento.horario,
         evento=evento


### PR DESCRIPTION
## Summary
- correct template paths in check-in routes
- update agendamento route to use correct subfolder

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a218a7ecc833288e6199b99ca1ae0