### PR TITLE
Fix register link in navbar

### DIFF
--- a/templates/partials/navbar.html
+++ b/templates/partials/navbar.html
@@ -38,7 +38,7 @@
                     <a class="btn btn-login" href="{{ url_for('auth_routes.login') }}">Entrar</a>
                 </li>
                 <li class="nav-item">
-                    <a class="btn btn-register" href="{{ url_for('inscricao_routes.cadastro_participante') }}">Cadastrar</a>
+                    <a class="btn btn-register" href="{{ url_for('evento_routes.listar_eventos') }}">Cadastrar</a>
                 </li>
                 {% else %}
                 <li class="nav-item dropdown">


### PR DESCRIPTION
## Summary
- fix the link for Cadastro in the public navbar to avoid build errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685082e04a748332a85b49e12df3a8bf