### PR TITLE
Atualiza navbar

### DIFF
--- a/templates/partials/navbar.html
+++ b/templates/partials/navbar.html
@@ -1,7 +1,7 @@
 {% set show_index_links = show_index_links | default(False) %}
 <nav class="navbar navbar-expand-lg navbar-light fixed-top">
     <div class="container">
-        <a class="navbar-brand" href="{{ url_for('dashboard_routes.dashboard') }}">
+        <a class="navbar-brand" href="{{ url_for('evento_routes.home') }}">
             <i class="bi bi-cpu"></i>App<span>Fiber</span>
         </a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
@@ -28,17 +28,9 @@
                         <i class="bi bi-download me-1"></i> Instalar App
                     </a>
                 </li>
-                <li class="nav-item me-2">
-                    <div class="theme-toggle nav-link" id="theme-toggle">
-                        <i class="bi bi-sun-fill" id="theme-icon"></i>
-                    </div>
-                </li>
                 {% if not current_user.is_authenticated %}
                 <li class="nav-item ms-lg-3">
                     <a class="btn btn-login" href="{{ url_for('auth_routes.login') }}">Entrar</a>
-                </li>
-                <li class="nav-item">
-                    <a class="btn btn-register" href="{{ url_for('evento_routes.listar_eventos') }}">Cadastrar</a>
                 </li>
                 {% else %}
                 <li class="nav-item dropdown">
@@ -47,12 +39,6 @@
                     </a>
                     <ul class="dropdown-menu dropdown-menu-end shadow-lg border-0">
                         {% if current_user.tipo == 'participante' %}
-                        <li>
-                            <a class="dropdown-item py-2" href="{{ url_for('inscricao_routes.editar_participante') }}">
-                                <i class="bi bi-person-badge me-2"></i>Editar Perfil
-                            </a>
-                        </li>
-                        <li><hr class="dropdown-divider my-1"></li>
                         <li>
                             <a class="dropdown-item py-2" href="{{ url_for('dashboard_participante_routes.dashboard_participante') }}">
                                 <i class="bi bi-speedometer2 me-2"></i>Dashboard


### PR DESCRIPTION
## Summary
- adapta navbar para direcionar a home e remover botões extras
- simplifica dropdown para conter apenas Dashboard e Sair
- remove botões de tema e cadastro

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850c9e5158083328dd72cb2d9d15a02