### PR TITLE
Handle non-string DB URIs

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,6 +22,10 @@ from services.mp_service import get_sdk
 def create_app():
     app = Flask(__name__)
     app.config.from_object(Config)
+    # Normaliza o URI para garantir que seja uma string
+    app.config['SQLALCHEMY_DATABASE_URI'] = Config.normalize_pg(
+        app.config['SQLALCHEMY_DATABASE_URI']
+    )
     # Recalcula as opções de conexão caso o URI tenha sido alterado nos testes
     app.config['SQLALCHEMY_ENGINE_OPTIONS'] = Config.build_engine_options(
         app.config['SQLALCHEMY_DATABASE_URI']

--- a/config.py
+++ b/config.py
@@ -44,6 +44,11 @@ class Config:
     )
 
     @staticmethod
+    def normalize_pg(uri: str | bytes) -> str:
+        """Proxy to the module-level normalize_pg."""
+        return normalize_pg(uri)
+
+    @staticmethod
     def build_engine_options(uri: str) -> dict:
         """Return engine options for the given database URI."""
         options = dict(


### PR DESCRIPTION
## Summary
- normalize DB URI string in `create_app`
- expose `Config.normalize_pg` helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68597243922083328fd2fc1cd6b9b356