### PR TITLE
Fix cadastro modal script on missing Leaflet

### DIFF
--- a/templates/auth/cadastro_participante.html
+++ b/templates/auth/cadastro_participante.html
@@ -900,7 +900,11 @@
         
         // Carregar estados e inicializar mapa
         loadBrazilianStates();
-        initMap();
+        if (typeof L !== 'undefined') {
+            initMap();
+        } else {
+            console.warn('Leaflet not loaded, skipping map initialization');
+        }
     });
     
     function updateHiddenFields(selectedOption) {


### PR DESCRIPTION
## Summary
- avoid crashing cadastro participante page if Leaflet isn't loaded

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6868364656d08332834bc9fce3707dfd