### PR TITLE
Remove duplicate route for registration

### DIFF
--- a/routes/evento_routes.py
+++ b/routes/evento_routes.py
@@ -73,7 +73,7 @@ def inscricao_evento(evento_id):
     if link:
         # Se existe um link personalizado, usa ele
         if link.slug_customizado:
-            return redirect(url_for('inscricao_routes.abrir_inscricao_customizada', slug=link.slug_customizado))
+            return redirect(url_for('inscricao_routes.cadastro_participante', identifier=link.slug_customizado))
         # Senão, usa o token
         return redirect(url_for('inscricao_routes.cadastro_participante', identifier=link.token))
     
@@ -127,9 +127,9 @@ def _serializa_eventos(eventos):
         if ev.links_cadastro:
             link = ev.links_cadastro[0]
             dado['link_inscricao'] = (
-                url_for('inscricao_routes.abrir_inscricao_customizada', slug=link.slug_customizado)
+                url_for('inscricao_routes.cadastro_participante', identifier=link.slug_customizado)
                 if link.slug_customizado else
-                url_for('inscricao_routes.abrir_inscricao_token', token=link.token)
+                url_for('inscricao_routes.cadastro_participante', identifier=link.token)
             )
         else:
             # Habilita inscrição se o evento estiver em andamento (data atual entre início e fim)

--- a/routes/inscricao_routes.py
+++ b/routes/inscricao_routes.py
@@ -835,10 +835,6 @@ def cancelar_inscricao(inscricao_id):
     else:
         return redirect(url_for('dashboard_routes.dashboard_cliente'))
     
-@inscricao_routes.route('/inscricao/<slug>')
-def abrir_inscricao_customizada(slug):
-    """Exibe o formulário de inscrição usando o slug personalizado."""
-    return cadastro_participante(slug)
 
 @inscricao_routes.route('/inscricao/token/<token>', methods=['GET', 'POST'])
 def abrir_inscricao_token(token):

--- a/templates/auth/cadastro_usuario.html
+++ b/templates/auth/cadastro_usuario.html
@@ -91,7 +91,7 @@
         {% endif %}
       {% endwith %}
 
-      <form method="POST" action="{{ url_for('inscricao_routes.cadastro_participante', token=token) if token else url_for('inscricao_routes.cadastro_participante') }}">
+      <form method="POST" action="{{ url_for('inscricao_routes.cadastro_participante', identifier=token) if token else url_for('inscricao_routes.cadastro_participante') }}">
         <div class="form-grid">
           <div>
             <label for="nome" class="form-label fw-semibold">Nome Completo</label>

--- a/tests/test_inscricao_routes.py
+++ b/tests/test_inscricao_routes.py
@@ -39,7 +39,12 @@ def app():
         db.session.add(lt)
         db.session.commit()
 
-        link = LinkCadastro(cliente_id=cliente.id, evento_id=evento.id, token='testtoken')
+        link = LinkCadastro(
+            cliente_id=cliente.id,
+            evento_id=evento.id,
+            token='testtoken',
+            slug_customizado='test-slug'
+        )
         db.session.add(link)
         db.session.commit()
 
@@ -57,6 +62,12 @@ def client(app):
 
 def test_get_inscricao_page(client):
     resp = client.get('/inscricao/token/testtoken')
+    assert resp.status_code == 200
+    assert b'Evento Teste' in resp.data
+
+
+def test_get_inscricao_page_slug(client):
+    resp = client.get('/inscricao/test-slug', follow_redirects=True)
     assert resp.status_code == 200
     assert b'Evento Teste' in resp.data
 


### PR DESCRIPTION
## Summary
- clean up inscrição routes by removing the redundant slug endpoint
- update event routes to link directly to `cadastro_participante`
- fix registration form template link
- expand inscrição route tests to cover slugs

## Testing
- `pytest tests/test_inscricao_routes.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_68768b5132dc83329d987e806c800532