### PR TITLE
Switch to wsgi entry for gunicorn

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn app:app --worker-class eventlet --bind 0.0.0.0:$PORT
+web: gunicorn wsgi:app --worker-class eventlet --bind 0.0.0.0:$PORT

--- a/README.md
+++ b/README.md
@@ -172,12 +172,10 @@ Esse script substitui o antigo `organizar_templates.sh`.
 
 ## Deployment
 
-The application exposes a module-level `app` inside `app.py`. To run it with
-Gunicorn in a production environment, use `eventlet` workers and bind to the
-`PORT` environment variable expected by most hosting platforms:
+Run the application with Gunicorn using the WSGI entry point from `wsgi.py`. Use `eventlet` workers and bind to the `PORT` environment variable expected by most hosting platforms:
 
 ```bash
-gunicorn app:app --worker-class eventlet --bind 0.0.0.0:$PORT
+gunicorn wsgi:app --worker-class eventlet --bind 0.0.0.0:$PORT
 ```
 
 The `eventlet` dependency is included in `requirements.txt`.

--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,7 @@ services:
     name: system-web
     env: python
     buildCommand: pip install -r requirements.txt
-    startCommand: gunicorn app:app  # from Procfile
+    startCommand: gunicorn wsgi:app --worker-class eventlet --bind 0.0.0.0:$PORT  # from Procfile
     envVars:
       - key: DATABASE_URL
         fromDatabase:


### PR DESCRIPTION
## Summary
- update Procfile to call Gunicorn via `wsgi:app`
- adjust Render config to use same command
- clarify README deployment instructions and update example command

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: werkzeug routing errors)*

------
https://chatgpt.com/codex/tasks/task_e_6878098a1e088332b10de295de99a358