### PR TITLE
Handle missing users when logging audit events

### DIFF
--- a/routes/formularios_routes.py
+++ b/routes/formularios_routes.py
@@ -444,9 +444,8 @@ def gerar_pdf_respostas_route(formulario_id):
 def get_resposta_file(filename):
     logger.debug("get_resposta_file foi chamado com: %s", filename)
     uploads_folder = os.path.join('uploads', 'respostas')
-    uid = current_user.id if hasattr(current_user, 'id') else None
-    if uid is not None and not Usuario.query.get(uid):
-        uid = None
+    usuario = Usuario.query.get(getattr(current_user, 'id', None))
+    uid = usuario.id if usuario else None  # permite salvar o log mesmo sem usuário
 
     # Caminho completo armazenado em RespostaCampo.valor
     caminho_arquivo = os.path.join('uploads', 'respostas', filename)
@@ -833,8 +832,9 @@ def definir_status_inline():
     # 4) Atualiza e registra log
     resposta.status_avaliacao = novo_status
 
-    # Obtém o ID do usuário autenticado de forma segura
-    uid = current_user.id if hasattr(current_user, "id") else None
+    # Obtém o registro de usuário; fallback a None se o usuário não existir
+    usuario = Usuario.query.get(getattr(current_user, "id", None))
+    uid = usuario.id if usuario else None  # permite salvar o log mesmo sem usuário
 
     # Determina a URL de retorno (prioriza a página anterior)
     redirect_url = request.referrer or url_for(

--- a/routes/peer_review_routes.py
+++ b/routes/peer_review_routes.py
@@ -56,6 +56,9 @@ def assign_reviews():
         flash("Acesso negado!", "danger")
         return redirect(url_for("dashboard_routes.dashboard"))
 
+    usuario = Usuario.query.get(getattr(current_user, "id", None))
+    uid = usuario.id if usuario else None  # salva log mesmo sem usuário
+
     data = request.get_json()
     if not data:
         return {"success": False}, 400
@@ -89,7 +92,7 @@ def assign_reviews():
             # Log -----------------------------------------------------------
             db.session.add(
                 AuditLog(
-                    user_id=current_user.id,
+                    user_id=uid,
                     submission_id=trabalho.id,
                     event_type="assignment",
                 )
@@ -108,6 +111,9 @@ def auto_assign(evento_id):
     if current_user.tipo not in ("cliente", "admin", "superadmin"):
         flash("Acesso negado!", "danger")
         return redirect(url_for("dashboard_routes.dashboard"))
+
+    usuario = Usuario.query.get(getattr(current_user, "id", None))
+    uid = usuario.id if usuario else None  # salva log mesmo sem usuário
 
     config = RevisaoConfig.query.filter_by(evento_id=evento_id).first()
     if not config:
@@ -147,7 +153,7 @@ def auto_assign(evento_id):
 
             db.session.add(
                 AuditLog(
-                    user_id=current_user.id,
+                    user_id=uid,
                     submission_id=t.id,
                     event_type="assignment",
                 )

--- a/routes/trabalho_routes.py
+++ b/routes/trabalho_routes.py
@@ -3,7 +3,7 @@ from flask_login import login_required, current_user
 from werkzeug.utils import secure_filename
 from utils.mfa import mfa_required
 from extensions import db
-from models import TrabalhoCientifico, AvaliacaoTrabalho, AuditLog, Evento
+from models import TrabalhoCientifico, AvaliacaoTrabalho, AuditLog, Evento, Usuario
 import uuid
 import os
 
@@ -79,9 +79,11 @@ def submeter_trabalho():
         locator = trabalho.locator
 
         # Audit log
+        usuario = Usuario.query.get(getattr(current_user, "id", None))
+        uid = usuario.id if usuario else None  # salva log mesmo sem usuário
         db.session.add(
             AuditLog(
-                user_id=current_user.id,
+                user_id=uid,
                 submission_id=trabalho.id,
                 event_type="submission",
             )
@@ -164,9 +166,11 @@ def avaliar_trabalho(trabalho_id):
         db.session.commit()
 
         # Audit log
+        usuario = Usuario.query.get(getattr(current_user, "id", None))
+        uid = usuario.id if usuario else None  # salva log mesmo sem usuário
         db.session.add(
             AuditLog(
-                user_id=current_user.id,
+                user_id=uid,
                 submission_id=trabalho.id,
                 event_type="decision",
             )


### PR DESCRIPTION
## Summary
- Safely look up the user record before writing audit logs and fall back to `None` when absent
- Apply the same audit logging pattern in binary, peer-review, and trabalho routes for consistency

## Testing
- `pytest` *(fails: SECRET_KEY environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_e_689a2c916cd483328e84dd5e63ef97d5