### PR TITLE
Fix missing parenthesis in participant form listing filter

### DIFF
--- a/routes/formularios_routes.py
+++ b/routes/formularios_routes.py
@@ -415,7 +415,7 @@ def listar_formularios_participante():
     query = query.filter(
         or_(Formulario.data_inicio == None, Formulario.data_inicio <= agora),
         or_(Formulario.data_fim == None, Formulario.data_fim >= agora)
-
+    )
     formularios = query.all()
 
     # Não há relação direta entre formulários e ministrantes no modelo atual,


### PR DESCRIPTION
## Summary
- ensure participant form listing filter closes properly and executes query

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils.dia_semana')*


------
https://chatgpt.com/codex/tasks/task_e_689a5e617e8083328e1ef32777899800