### PR TITLE
Fix criar_formulario route indentation and POST handling

### DIFF
--- a/routes/formularios_routes.py
+++ b/routes/formularios_routes.py
@@ -86,102 +86,55 @@ def criar_formulario():
         else Evento.query.all()
     )
 
-    config_cli = ConfiguracaoCliente.query.filter_by(cliente_id=current_user.id).first()
-if request.method == "POST":
-    count_forms = Formulario.query.filter_by(cliente_id=current_user.id).count()
-    if (
-        config_cli
-        and config_cli.limite_formularios is not None
-        and count_forms >= config_cli.limite_formularios
-    ):
-        flash("Limite de formulários atingido.", "danger")
+    config_cli = ConfiguracaoCliente.query.filter_by(
+        cliente_id=current_user.id
+    ).first()
+
+    if request.method == "POST":
+        count_forms = Formulario.query.filter_by(cliente_id=current_user.id).count()
+        if (
+            config_cli
+            and config_cli.limite_formularios is not None
+            and count_forms >= config_cli.limite_formularios
+        ):
+            flash("Limite de formulários atingido.", "danger")
+            return redirect(url_for("formularios_routes.listar_formularios"))
+
+        nome = request.form.get("nome")
+        descricao = request.form.get("descricao")
+        data_inicio_str = request.form.get("data_inicio")
+        data_fim_str = request.form.get("data_fim")
+        evento_ids = request.form.getlist("eventos")
+
+        # Checkbox marcado => True; ausente => False
+        permitir_multiplas = "permitir_multiplas_respostas" in request.form
+
+        data_inicio = (
+            datetime.strptime(data_inicio_str, "%Y-%m-%dT%H:%M") if data_inicio_str else None
+        )
+        data_fim = (
+            datetime.strptime(data_fim_str, "%Y-%m-%dT%H:%M") if data_fim_str else None
+        )
+
+        novo_formulario = Formulario(
+            nome=nome,
+            descricao=descricao,
+            data_inicio=data_inicio,
+            data_fim=data_fim,
+            permitir_multiplas_respostas=permitir_multiplas,
+            cliente_id=current_user.id,
+        )
+
+        if evento_ids:
+            eventos_sel = Evento.query.filter(Evento.id.in_(evento_ids)).all()
+            novo_formulario.eventos = eventos_sel
+
+        db.session.add(novo_formulario)
+        db.session.commit()
+        flash("Formulário criado com sucesso!", "success")
         return redirect(url_for("formularios_routes.listar_formularios"))
 
-    nome = request.form.get("nome")
-    descricao = request.form.get("descricao")
-    data_inicio_str = request.form.get("data_inicio")
-    data_fim_str = request.form.get("data_fim")
-    evento_ids = request.form.getlist("eventos")
-    # Checkbox marcado => True; ausente => False
-    permitir_multiplas = "permitir_multiplas_respostas" in request.form
-
-    data_inicio = (
-        datetime.strptime(data_inicio_str, "%Y-%m-%dT%H:%M") if data_inicio_str else None
-    )
-    data_fim = (
-        datetime.strptime(data_fim_str, "%Y-%m-%dT%H:%M") if data_fim_str else None
-    )
-if request.method == "POST":
-    count_forms = Formulario.query.filter_by(cliente_id=current_user.id).count()
-    if (
-        config_cli
-        and config_cli.limite_formularios is not None
-        and count_forms >= config_cli.limite_formularios
-    ):
-        flash("Limite de formulários atingido.", "danger")
-        return redirect(url_for("formularios_routes.listar_formularios"))
-
-    nome = request.form.get("nome")
-    descricao = request.form.get("descricao")
-    data_inicio_str = request.form.get("data_inicio")
-    data_fim_str = request.form.get("data_fim")
-    evento_ids = request.form.getlist("eventos")
-
-    # Checkbox marcado => True; ausente => False
-    permitir_multiplas = "permitir_multiplas_respostas" in request.form
-
-    data_inicio = (
-        datetime.strptime(data_inicio_str, "%Y-%m-%dT%H:%M") if data_inicio_str else None
-    )
-    data_fim = (
-        datetime.strptime(data_fim_str, "%Y-%m-%dT%H:%M") if data_fim_str else None
-    )
-
-if request.method == "POST":
-    count_forms = Formulario.query.filter_by(cliente_id=current_user.id).count()
-    if (
-        config_cli
-        and config_cli.limite_formularios is not None
-        and count_forms >= config_cli.limite_formularios
-    ):
-        flash("Limite de formulários atingido.", "danger")
-        return redirect(url_for("formularios_routes.listar_formularios"))
-
-    nome = request.form.get("nome")
-    descricao = request.form.get("descricao")
-    data_inicio_str = request.form.get("data_inicio")
-    data_fim_str = request.form.get("data_fim")
-    evento_ids = request.form.getlist("eventos")
-
-    # Checkbox marcado => True; ausente => False
-    permitir_multiplas = "permitir_multiplas_respostas" in request.form
-
-    data_inicio = (
-        datetime.strptime(data_inicio_str, "%Y-%m-%dT%H:%M") if data_inicio_str else None
-    )
-    data_fim = (
-        datetime.strptime(data_fim_str, "%Y-%m-%dT%H:%M") if data_fim_str else None
-    )
-
-    novo_formulario = Formulario(
-        nome=nome,
-        descricao=descricao,
-        data_inicio=data_inicio,
-        data_fim=data_fim,
-        permitir_multiplas_respostas=permitir_multiplas,
-        cliente_id=current_user.id,
-    )
-
-    if evento_ids:
-        eventos_sel = Evento.query.filter(Evento.id.in_(evento_ids)).all()
-        novo_formulario.eventos = eventos_sel
-
-    db.session.add(novo_formulario)
-    db.session.commit()
-    flash("Formulário criado com sucesso!", "success")
-    return redirect(url_for("formularios_routes.listar_formularios"))
-
-return render_template("criar_formulario.html", eventos=eventos_disponiveis)
+    return render_template("criar_formulario.html", eventos=eventos_disponiveis)
 
 
 


### PR DESCRIPTION
## Summary
- Fix indentation of criar_formulario in formularios_routes
- Consolidate duplicated POST logic into single block

## Testing
- `pytest tests/test_agendamento_flow.py -q` *(fails: ModuleNotFoundError: No module named 'utils.dia_semana')*

------
https://chatgpt.com/codex/tasks/task_e_689a60d88b58833290e398c05f5d5ea0