### PR TITLE
Ensure only authorized users can delete forms

### DIFF
--- a/routes/formularios_routes.py
+++ b/routes/formularios_routes.py
@@ -190,6 +190,14 @@ return render_template("criar_formulario.html", eventos=eventos_disponiveis)
 @login_required
 def deletar_formulario(formulario_id):
     formulario = Formulario.query.get_or_404(formulario_id)
+
+    if (
+        getattr(current_user, "tipo", None) not in ("admin", "superadmin")
+        and formulario.cliente_id != current_user.id
+    ):
+        flash("Você não tem permissão para deletar este formulário.", "danger")
+        return redirect(url_for("formularios_routes.listar_formularios"))
+
     db.session.delete(formulario)
     db.session.commit()
     flash("Formulário deletado com sucesso!", "success")


### PR DESCRIPTION
## Summary
- Require admin, superadmin, or owner to delete a form
- Inform unauthorized users and redirect instead of deleting

## Testing
- `pytest` (fails: 34 errors during collection)


------
https://chatgpt.com/codex/tasks/task_e_689a60d9ee088332b98f2770a6fcf82d