### PR TITLE
feat(logging): make log level configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # Flask secret key used for session signing
 SECRET_KEY=
 
+# Logging level (default INFO; use DEBUG for development)
+LOG_LEVEL=DEBUG
+
 # Mailjet credentials for outgoing emails
 MAILJET_API_KEY=
 MAILJET_SECRET_KEY=

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ export MAIL_DEFAULT_SENDER="seu_email@exemplo.com"
 export GOOGLE_CLIENT_ID="<cliente_id_do_google>"
 export GOOGLE_CLIENT_SECRET="<cliente_secret_do_google>"
 export SECRET_KEY="<sua_chave_secreta>"
+export LOG_LEVEL="DEBUG"
 export APP_BASE_URL="https://seu-dominio.com"
 export RECAPTCHA_PUBLIC_KEY="<sua_chave_publica_recaptcha>"
 export RECAPTCHA_PRIVATE_KEY="<sua_chave_privada_recaptcha>"
@@ -24,7 +25,10 @@ export DB_LOCAL="<url_do_banco_local>"
 As variáveis `SECRET_KEY`, `GOOGLE_CLIENT_ID` e `GOOGLE_CLIENT_SECRET` são **obrigatórias**.
 A `SECRET_KEY` deve ser um valor forte e aleatório; a aplicação encerrará a
 inicialização caso qualquer uma delas não esteja definida no ambiente. As
-chaves do Google são necessárias para a autenticação via Gmail.
+chaves do Google são necessárias para a autenticação via Gmail. A variável
+`LOG_LEVEL` controla a verbosidade do log e, se não definida, assume `INFO`,
+reduzindo o volume de mensagens em produção. Ajuste para `DEBUG` durante o
+desenvolvimento para obter logs mais detalhados.
 
 ## Banco de Dados
 

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ import logging
 
 # Configuração centralizada de logging
 logging.basicConfig(
-    level=logging.DEBUG if Config.DEBUG else logging.INFO,
+    level=getattr(logging, Config.LOG_LEVEL, logging.INFO),
     format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
 )
 

--- a/config.py
+++ b/config.py
@@ -34,6 +34,11 @@ class Config:
     DEBUG = os.getenv("FLASK_DEBUG", "1") == "1"
 
     # ------------------------------------------------------------------ #
+    #  Logging                                                           #
+    # ------------------------------------------------------------------ #
+    LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+
+    # ------------------------------------------------------------------ #
     #  Parâmetros individuais (podem vir de .env ou variáveis do sistema) #
     # ------------------------------------------------------------------ #
     DB_USER = os.getenv("DB_USER", "postgres")


### PR DESCRIPTION
## Summary
- allow configuring log level via `LOG_LEVEL` env var
- document `LOG_LEVEL` in example environment file and README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'utils.dia_semana')*
- `LOG_LEVEL=INFO SECRET_KEY=dummy python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_689a70f242308332920946bf5a2f5992