### PR TITLE
feat: skip preco zero

### DIFF
--- a/services/pdf_service.py
+++ b/services/pdf_service.py
@@ -3408,6 +3408,12 @@ def preco_com_taxa(base):
     Recebe o preço digitado pelo cliente (Decimal, str ou float)
     e devolve o valor acrescido do percentual configurado.
     """
+    if not base:
+        try:
+            return Decimal(str(base)).quantize(Decimal("0.01"), ROUND_HALF_UP)
+        except Exception:
+            return Decimal("0").quantize(Decimal("0.01"), ROUND_HALF_UP)
+
     base = Decimal(str(base))
     cfg  = Configuracao.query.first()
     perc = Decimal(str(cfg.taxa_percentual_inscricao or 0))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,6 +23,9 @@ def test_arquivo_permitido_extensoes_rejeitadas():
 
 
 def test_determinar_turno():
+    import os
+    os.environ.setdefault("GOOGLE_CLIENT_ID", "x")
+    os.environ.setdefault("GOOGLE_CLIENT_SECRET", "x")
     from utils.time_helpers import determinar_turno
     from pytz import timezone
     from datetime import datetime
@@ -35,3 +38,22 @@ def test_determinar_turno():
     assert determinar_turno(manha) == "Matutino"
     assert determinar_turno(tarde) == "Vespertino"
     assert determinar_turno(noite) == "Noturno"
+
+
+def test_preco_com_taxa_falsy_base(monkeypatch, caplog):
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "dummy")
+    monkeypatch.setenv("GOOGLE_CLIENT_SECRET", "dummy")
+
+    import importlib.util, pathlib, logging
+    spec = importlib.util.spec_from_file_location(
+        "utils", pathlib.Path(__file__).resolve().parents[1] / "utils" / "__init__.py"
+    )
+    utils = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(utils)
+
+    caplog.set_level(logging.DEBUG)
+    result = utils.preco_com_taxa(0)
+
+    from decimal import Decimal
+    assert result == Decimal("0.00")
+    assert "Calculando preço com taxa" not in caplog.text

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -78,6 +78,12 @@ def preco_com_taxa(base, cliente_id=None):
     Returns:
         Decimal: Valor com taxa aplicada
     """
+    if not base:
+        try:
+            return Decimal(str(base)).quantize(Decimal("0.01"), ROUND_HALF_UP)
+        except Exception:
+            return Decimal("0").quantize(Decimal("0.01"), ROUND_HALF_UP)
+
     logger = logging.getLogger("preco_com_taxa")
     logger.debug(f"Calculando preço com taxa - base: {base}, cliente_id: {cliente_id}")
     


### PR DESCRIPTION
## Summary
- avoid logging and DB queries when preco_com_taxa receives zero
- return early in PDF preco calculation
- test preco_com_taxa for zero input and silence

## Testing
- `pytest tests/test_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689a710724908332b558be2ef547ef0f