### PR TITLE
Add AGENTS guide and link from README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# Contributor Guidelines
+
+## Coding Conventions
+- Follow [PEP 8](https://peps.python.org/pep-0008/) style with 4-space indentation.
+- Keep lines under 88 characters when possible.
+- Use descriptive names and include docstrings for public functions and classes.
+
+## Commit Practices
+- Make small, atomic commits.
+- Start commit messages with a short imperative summary (<72 chars).
+- Reference related issues in the commit body when applicable.
+
+## Testing Requirements
+- Install development dependencies: `pip install -r requirements-dev.txt`.
+- Run the test suite with `pytest` and ensure all tests pass before committing.
+
+By contributing to this repository you agree to follow these guidelines.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 A Flask-based management system.
 
+## Contribuição
+
+Consulte [AGENTS.md](AGENTS.md) para convenções de código, práticas de commit e requisitos de testes. Siga essas orientações ao colaborar.
+
+
 ## Configuracao
 
 Defina as variaveis de ambiente abaixo antes de iniciar a aplicacao (veja


### PR DESCRIPTION
## Summary
- add AGENTS.md with coding conventions, commit guidelines, and testing requirements
- mention AGENTS.md in README to guide contributors

## Testing
- `pytest` (failed: 34 errors during collection)

------
https://chatgpt.com/codex/tasks/task_e_689a711f95b48332b4f84b76c050a329