### PR TITLE
chore: unify formulario period migrations

### DIFF
--- a/migrations/versions/40d6f21cfd81_unify_periodo_fields.py
+++ b/migrations/versions/40d6f21cfd81_unify_periodo_fields.py
@@ -1,0 +1,27 @@
+"""merge period-related migrations for formularios
+
+Revision ID: 40d6f21cfd81
+Revises: f3d9f9a5e8d2
+Create Date: 2025-01-01 00:00:00.000000
+
+This migration consolidates the history of period fields on the
+``formularios`` table.  No schema changes are performed.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "40d6f21cfd81"
+down_revision = "f3d9f9a5e8d2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass
+

--- a/migrations/versions/f3d9f9a5e8d2_add_data_inicio_data_fim_to_formulario.py
+++ b/migrations/versions/f3d9f9a5e8d2_add_data_inicio_data_fim_to_formulario.py
@@ -1,8 +1,14 @@
-"""add data_inicio and data_fim to formulario
+"""historic placeholder for period fields on ``formularios``
 
 Revision ID: f3d9f9a5e8d2
-Revises: 15b6b890ce1d
+Revises: a4e781302f2b
 Create Date: 2024-08-11 20:38:00.000000
+
+This revision originally attempted to add the ``data_inicio`` and
+``data_fim`` columns to the ``formularios`` table.  Those columns were
+introduced earlier in ``a4e781302f2b``.  The operations were removed to
+avoid duplicate column errors, leaving this migration as a no-op that
+preserves the historical record.
 """
 
 from alembic import op
@@ -10,16 +16,14 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "f3d9f9a5e8d2"
-down_revision = "15b6b890ce1d"
+down_revision = "a4e781302f2b"
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
-    op.add_column("formularios", sa.Column("data_inicio", sa.DateTime(), nullable=True))
-    op.add_column("formularios", sa.Column("data_fim", sa.DateTime(), nullable=True))
+    pass
 
 
 def downgrade():
-    op.drop_column("formularios", "data_inicio")
-    op.drop_column("formularios", "data_fim")
+    pass


### PR DESCRIPTION
## Summary
- linearize historical period migrations on `formularios`
- add placeholder revision documenting prior duplicate `data_inicio`/`data_fim` additions

## Testing
- `flask db upgrade 40d6f21cfd81` *(fails: No support for ALTER of constraints in SQLite dialect)*

------
https://chatgpt.com/codex/tasks/task_e_689a71252f208332aecea763e85e27cf