### PR TITLE
Remove feedbacks when deleting responses

### DIFF
--- a/models.py
+++ b/models.py
@@ -901,7 +901,10 @@ class FeedbackCampo(db.Model):
 
     # Relacionamentos
     resposta_campo = db.relationship(
-        "RespostaCampo", backref=db.backref("feedbacks_campo", lazy=True)
+        "RespostaCampo",
+        backref=db.backref(
+            "feedbacks_campo", lazy=True, cascade="all, delete-orphan"
+        ),
     )
     ministrante = db.relationship(
         "Ministrante", backref=db.backref("feedbacks_campo", lazy=True)

--- a/routes/formularios_routes.py
+++ b/routes/formularios_routes.py
@@ -956,12 +956,17 @@ def deletar_resposta(resposta_id):
 
     # Remove arquivos associados e registros de RespostaCampo
     for resp_campo in list(resposta.respostas_campos):
+        # Remove feedbacks vinculados ao campo antes da exclusão
+        for feedback in list(resp_campo.feedbacks_campo):
+            db.session.delete(feedback)
+
         if resp_campo.campo.tipo == 'file' and resp_campo.valor:
             try:
                 if os.path.exists(resp_campo.valor):
                     os.remove(resp_campo.valor)
             except OSError:
                 logger.exception('Erro ao remover arquivo %s', resp_campo.valor)
+
         db.session.delete(resp_campo)
 
     # Remove diretório da resposta (se existir)


### PR DESCRIPTION
## Summary
- cascade delete FeedbackCampo records with RespostaCampo
- drop feedbacks before removing response fields

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: Interrupted with 34 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689a8e1674948332b46e8c8cb3b98cde