### PR TITLE
Update agendamento listing template for AgendamentoVisita

### DIFF
--- a/templates/agendamento/listar_agendamentos.html
+++ b/templates/agendamento/listar_agendamentos.html
@@ -111,7 +111,7 @@
               <th>Data</th>
               <th>Horário</th>
               <th>Oficina</th>
-              <th>Participante</th>
+              <th>Professor</th>
               <th>Status</th>
               <th class="text-center">Ações</th>
             </tr>
@@ -121,10 +121,10 @@
               {% for agendamento in agendamentos %}
                 <tr>
                   <td>{{ agendamento.id }}</td>
-                  <td>{{ agendamento.data.strftime('%d/%m/%Y') }}</td>
-                  <td>{{ agendamento.horario_inicio }} - {{ agendamento.horario_fim }}</td>
-                  <td>{{ agendamento.oficina.titulo }}</td>
-                  <td>{{ agendamento.usuario.nome }}</td>
+                  <td>{{ agendamento.horario.data.strftime('%d/%m/%Y') }}</td>
+                  <td>{{ agendamento.horario.horario_inicio }} - {{ agendamento.horario.horario_fim }}</td>
+                  <td>{{ agendamento.horario.evento.titulo }}</td>
+                  <td>{{ agendamento.professor.nome }}</td>
                   <td>
                     {% set status_badges = {
                       'pendente': 'warning',
@@ -142,14 +142,14 @@
                         <i class="bi bi-eye"></i>
                       </a>
                       
-                      {% if current_user.tipo in ['admin', 'cliente', 'ministrante'] or current_user.id == agendamento.usuario_id %}
+                      {% if current_user.tipo in ['admin', 'cliente', 'ministrante'] or current_user.id == agendamento.professor_id %}
                         <a href="{{ url_for('agendamento_routes.editar_agendamento', agendamento_id=agendamento.id) }}" 
                            class="btn btn-outline-warning" data-bs-toggle="tooltip" title="Editar">
                           <i class="bi bi-pencil"></i>
                         </a>
                       {% endif %}
                       
-                      {% if current_user.tipo in ['admin', 'cliente'] or current_user.id == agendamento.usuario_id %}
+                      {% if current_user.tipo in ['admin', 'cliente'] or current_user.id == agendamento.professor_id %}
                         <button type="button"
                                 class="btn btn-outline-danger"
                                 data-bs-toggle="modal"


### PR DESCRIPTION
## Summary
- Use horario data and times for agendamento listings
- Display event title and professor name in listing
- Adjust permission checks to rely on professor_id

## Testing
- `pytest` *(fails: Interrupted: 34 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689a95a1ee2883329b5b27a8662edeff