### PR TITLE
Restrict ministrante from editing agendamentos

### DIFF
--- a/templates/agendamento/listar_agendamentos.html
+++ b/templates/agendamento/listar_agendamentos.html
@@ -142,8 +142,9 @@
                         <i class="bi bi-eye"></i>
                       </a>
                       
-                      {% if current_user.tipo in ['admin', 'cliente', 'ministrante'] or current_user.id == agendamento.professor_id %}
-                        <a href="{{ url_for('agendamento_routes.editar_agendamento', agendamento_id=agendamento.id) }}" 
+                      {% if current_user.tipo in ['admin', 'cliente'] or
+                            current_user.id == agendamento.professor_id %}
+                        <a href="{{ url_for('agendamento_routes.editar_agendamento', agendamento_id=agendamento.id) }}"
                            class="btn btn-outline-warning" data-bs-toggle="tooltip" title="Editar">
                           <i class="bi bi-pencil"></i>
                         </a>


### PR DESCRIPTION
## Summary
- hide edit button from `ministrante` in agendamentos list

## Testing
- `pytest` *(fails: BuildError, AssertionError, AttributeError, RuntimeError, TypeError, TemplateNotFound)*

------
https://chatgpt.com/codex/tasks/task_e_689b5d4578c08332acab890be279cc5a