### PR TITLE
Align agendamento status buttons with permissions

### DIFF
--- a/templates/agendamento/listar_agendamentos.html
+++ b/templates/agendamento/listar_agendamentos.html
@@ -149,7 +149,7 @@
                         </a>
                       {% endif %}
                       
-                      {% if current_user.tipo in ['admin', 'cliente'] or current_user.id == agendamento.professor_id %}
+                      {% if current_user.is_admin or current_user.id == agendamento.professor_id %}
                         <button type="button"
                                 class="btn btn-outline-danger"
                                 data-bs-toggle="modal"
@@ -159,8 +159,8 @@
                           <i class="bi bi-x-circle"></i>
                         </button>
                       {% endif %}
-                      
-                      {% if current_user.tipo in ['admin', 'cliente', 'ministrante'] %}
+
+                      {% if current_user.is_admin or current_user.id == agendamento.professor_id %}
                         <button type="button"
                                 class="btn btn-outline-success"
                                 data-bs-toggle="modal"
@@ -169,7 +169,7 @@
                                 title="Confirmar">
                           <i class="bi bi-check-circle"></i>
                         </button>
-                        
+
                         <button type="button"
                                 class="btn btn-outline-primary"
                                 data-bs-toggle="modal"


### PR DESCRIPTION
## Summary
- restrict status update actions in agendamento list to admins or agendamento owners

## Testing
- `pytest` *(fails: 37 failed, 47 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689b5d72d0f08332bebee62b34cdb510