### PR TITLE
Allow clients to schedule visits

### DIFF
--- a/models.py
+++ b/models.py
@@ -1138,7 +1138,7 @@ class HorarioVisitacao(db.Model):
 
 
 class AgendamentoVisita(db.Model):
-    """Agendamento realizado por um professor para uma turma."""
+    """Agendamento de visitação por professores ou clientes."""
 
     __tablename__ = "agendamento_visita"
 
@@ -1146,7 +1146,15 @@ class AgendamentoVisita(db.Model):
     horario_id = db.Column(
         db.Integer, db.ForeignKey("horario_visitacao.id"), nullable=False
     )
-    professor_id = db.Column(db.Integer, db.ForeignKey("usuario.id"), nullable=False)
+    professor_id = db.Column(
+        db.Integer, db.ForeignKey("usuario.id"), nullable=True
+    )
+    usuario_id = db.Column(
+        db.Integer, db.ForeignKey("usuario.id"), nullable=True
+    )
+    cliente_id = db.Column(
+        db.Integer, db.ForeignKey("cliente.id"), nullable=True
+    )
 
     # Informações da escola e turma
     escola_nome = db.Column(db.String(200), nullable=False)
@@ -1179,7 +1187,17 @@ class AgendamentoVisita(db.Model):
         "HorarioVisitacao", backref=db.backref("agendamentos", lazy=True)
     )
     professor = db.relationship(
-        "Usuario", backref=db.backref("agendamentos_visitas", lazy=True)
+        "Usuario",
+        foreign_keys=[professor_id],
+        backref=db.backref("agendamentos_visitas", lazy=True),
+    )
+    usuario = db.relationship(
+        "Usuario",
+        foreign_keys=[usuario_id],
+        backref=db.backref("agendamentos_criados", lazy=True),
+    )
+    cliente = db.relationship(
+        "Cliente", backref=db.backref("agendamentos_visitas", lazy=True)
     )
 
     def __init__(self, **kwargs):
@@ -1189,7 +1207,8 @@ class AgendamentoVisita(db.Model):
         self.qr_code_token = str(uuid.uuid4())
 
     def __repr__(self):
-        return f"<AgendamentoVisita {self.id} - Prof. {self.professor.nome} - {self.escola_nome}>"
+        nome = self.professor.nome if self.professor else "Cliente"
+        return f"<AgendamentoVisita {self.id} - {nome} - {self.escola_nome}>"
 
 
 class AlunoVisitante(db.Model):

--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -1101,9 +1101,12 @@ def criar_agendamento():
     form_erro = None
     eventos = []
     
-    # Buscar eventos disponíveis do cliente atual
+    # Buscar eventos disponíveis conforme o tipo de usuário
     try:
-        eventos = Evento.query.filter_by(cliente_id=current_user.id).all()
+        if getattr(current_user, 'is_cliente', lambda: False)():
+            eventos = Evento.query.filter_by(cliente_id=current_user.id).all()
+        else:
+            eventos = Evento.query.all()
     except Exception as e:
         flash(f"Erro ao buscar eventos: {str(e)}", "danger")
     
@@ -1138,13 +1141,35 @@ def criar_agendamento():
                         form_erro = f"Não há vagas suficientes! Disponíveis: {horario.vagas_disponiveis}"
                         flash(form_erro, "danger")
                     else:
+                        professor_id = None
+                        cliente_id = None
+                        usuario_id = None
+                        if getattr(current_user, 'is_cliente', lambda: False)():
+                            cliente = Cliente.query.get(current_user.id)
+                            if not cliente:
+                                form_erro = 'Cliente inválido.'
+                                flash(form_erro, 'danger')
+                                return redirect(url_for('agendamento_routes.criar_agendamento'))
+                            cliente_id = cliente.id
+                        else:
+                            usuario = Usuario.query.get(current_user.id)
+                            if not usuario:
+                                form_erro = 'Usuário inválido.'
+                                flash(form_erro, 'danger')
+                                return redirect(url_for('agendamento_routes.criar_agendamento'))
+                            usuario_id = usuario.id
+                            if getattr(usuario, 'is_professor', lambda: False)():
+                                professor_id = usuario.id
+
                         agendamento = AgendamentoVisita(
                             horario_id=horario.id,
-                            professor_id=current_user.id,
+                            professor_id=professor_id,
+                            usuario_id=usuario_id,
+                            cliente_id=cliente_id,
                             escola_nome=escola_nome,
                             turma=turma,
                             nivel_ensino=faixa_etaria,
-                            quantidade_alunos=quantidade
+                            quantidade_alunos=quantidade,
                         )
 
                         horario.vagas_disponiveis -= quantidade
@@ -1153,7 +1178,12 @@ def criar_agendamento():
                         try:
                             db.session.commit()
                             flash("Agendamento criado com sucesso!", "success")
-                            return redirect(url_for('routes.adicionar_alunos_agendamento', agendamento_id=agendamento.id))
+                            return redirect(
+                                url_for(
+                                    'routes.adicionar_alunos_agendamento',
+                                    agendamento_id=agendamento.id,
+                                )
+                            )
                         except Exception as e:
                             db.session.rollback()
                             form_erro = f"Erro ao salvar agendamento: {str(e)}"
@@ -3119,9 +3149,15 @@ def cadastro_professor():
 @agendamento_routes.route('/agendar_visita/<int:horario_id>', methods=['GET', 'POST'])
 @login_required
 def agendar_visita(horario_id):
-    if not current_user.is_professor():
-        flash('Apenas professores podem fazer agendamentos.', 'danger')
-        return redirect(url_for('dashboard_participante_routes.dashboard_participante'))
+    """Permite que professores ou clientes agendem visitas."""
+    is_professor = getattr(current_user, 'is_professor', lambda: False)()
+    is_cliente = getattr(current_user, 'is_cliente', lambda: False)()
+    if not (is_professor or is_cliente):
+        msg = 'Apenas professores ou clientes podem fazer agendamentos.'
+        flash(msg, 'danger')
+        return redirect(
+            url_for('dashboard_participante_routes.dashboard_participante')
+        )
 
     horario = HorarioVisitacao.query.get_or_404(horario_id)
 
@@ -3143,14 +3179,38 @@ def agendar_visita(horario_id):
             flash('Quantidade de alunos excede vagas disponíveis.', 'danger')
             return redirect(url_for('agendamento_routes.agendar_visita', horario_id=horario_id))
 
+        # Validar usuário/cliente
+        professor_id = None
+        cliente_id = None
+        usuario_id = None
+        if is_professor:
+            professor = Usuario.query.get(current_user.id)
+            if not professor:
+                flash('Professor não encontrado.', 'danger')
+                return redirect(
+                    url_for('agendamento_routes.agendar_visita', horario_id=horario_id)
+                )
+            professor_id = professor.id
+            usuario_id = professor.id
+        else:
+            cliente = Cliente.query.get(current_user.id)
+            if not cliente:
+                flash('Cliente não encontrado.', 'danger')
+                return redirect(
+                    url_for('agendamento_routes.agendar_visita', horario_id=horario_id)
+                )
+            cliente_id = cliente.id
+
         # Criar agendamento
         novo_agendamento = AgendamentoVisita(
             horario_id=horario.id,
-            professor_id=current_user.id,
+            professor_id=professor_id,
+            usuario_id=usuario_id,
+            cliente_id=cliente_id,
             escola_nome=escola_nome,
             turma=turma,
             nivel_ensino=nivel_ensino,
-            quantidade_alunos=quantidade_alunos
+            quantidade_alunos=quantidade_alunos,
         )
 
         # Reduzir vagas disponíveis

--- a/templates/agendamento/agendar_visita.html
+++ b/templates/agendamento/agendar_visita.html
@@ -3,12 +3,21 @@
 {% block content %}
 <div class="container mt-4">
     <h2>Agendar Visita</h2>
+    <p class="text-muted">
+        Você está agendando como
+        {{ 'Professor' if current_user.is_professor() else 'Cliente' }}.
+    </p>
     <p><strong>Data:</strong> {{ horario.data }}</p>
     <p><strong>Horário:</strong> {{ horario.horario_inicio }} - {{ horario.horario_fim }}</p>
     <p><strong>Vagas Disponíveis:</strong> {{ horario.vagas_disponiveis }}</p>
 
     <form method="POST">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        {% if current_user.is_professor() %}
+        <input type="hidden" name="professor_id" value="{{ current_user.id }}">
+        {% elif current_user.is_cliente() %}
+        <input type="hidden" name="cliente_id" value="{{ current_user.id }}">
+        {% endif %}
         <div class="mb-3">
             <label class="form-label">Nome da Escola</label>
             <input type="text" name="escola_nome" class="form-control" required>

--- a/templates/agendamento/criar_agendamento.html
+++ b/templates/agendamento/criar_agendamento.html
@@ -12,6 +12,11 @@
     </a>
   </div>
 
+  <p class="text-muted mb-4">
+    Você está agendando como
+    {{ 'Professor' if current_user.is_professor() else 'Cliente' }}.
+  </p>
+
   <div class="card shadow">
     <div class="card-body">
       {% if form_erro %}
@@ -22,6 +27,12 @@
 
       <form method="POST" action="{{ url_for('agendamento_routes.criar_agendamento') }}">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          {% if current_user.is_professor() %}
+          <input type="hidden" name="professor_id" value="{{ current_user.id }}">
+          <input type="hidden" name="usuario_id" value="{{ current_user.id }}">
+          {% elif current_user.is_cliente() %}
+          <input type="hidden" name="cliente_id" value="{{ current_user.id }}">
+          {% endif %}
         <div class="row">
           <!-- Coluna 1: Informações do Evento -->
           <div class="col-md-6">

--- a/templates/professor/criar_agendamento.html
+++ b/templates/professor/criar_agendamento.html
@@ -6,6 +6,7 @@
 {% block content %}
 <div class="container mt-4">
     <h2>Criar Agendamento</h2>
+    <p class="text-muted">Você está agendando como Professor.</p>
     
     <div class="card mb-4">
         <div class="card-header bg-primary text-white">
@@ -32,6 +33,8 @@
         </div>
         <div class="card-body">
             <form method="POST" action="{{ url_for('routes.criar_agendamento_professor', horario_id=horario.id) }}">
+                <input type="hidden" name="professor_id" value="{{ current_user.id }}">
+                <input type="hidden" name="usuario_id" value="{{ current_user.id }}">
                 <div class="row">
                     <div class="col-md-6 mb-3">
                         <label for="escola_nome" class="form-label">Nome da Escola *</label>

--- a/tests/test_agendamento_flow.py
+++ b/tests/test_agendamento_flow.py
@@ -219,6 +219,38 @@ def test_fluxo_agendamento(app):
     assert resp.status_code == 200
     assert resp.data.startswith(b'PDF')
 
+    with app.app_context():
+        agendamento = AgendamentoVisita.query.get(agendamento_id)
+        assert agendamento.professor_id is not None
+        assert agendamento.cliente_id is None
+
+
+def test_cliente_cria_agendamento(app):
+    client = app.test_client()
+
+    login(client, 'cli@test', '123')
+
+    with app.app_context():
+        horario = HorarioVisitacao.query.first()
+
+    resp = client.post(
+        f'/agendar_visita/{horario.id}',
+        data={
+            'escola_nome': 'Escola C',
+            'turma': 'T1',
+            'nivel_ensino': 'Fundamental',
+            'quantidade_alunos': 5,
+        },
+        follow_redirects=False,
+    )
+
+    assert resp.status_code == 302
+
+    with app.app_context():
+        agendamento = AgendamentoVisita.query.first()
+        assert agendamento.cliente_id is not None
+        assert agendamento.professor_id is None
+
 
 def test_editar_agendamento_shows_current_when_full(app):
     client = app.test_client()


### PR DESCRIPTION
## Summary
- allow both professors and clients to schedule visits
- record creator type in `AgendamentoVisita`
- adjust templates and tests for client scheduling

## Testing
- `pytest` *(fails: BuildError, TemplateNotFound, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689bda3731908332ae376b77e42177a9