### PR TITLE
Add cliente association to visit scheduling

### DIFF
--- a/migrations/versions/f3c52d6c9b16_add_cliente_id_to_agendamento_visita.py
+++ b/migrations/versions/f3c52d6c9b16_add_cliente_id_to_agendamento_visita.py
@@ -1,0 +1,34 @@
+"""add cliente_id to agendamento_visita
+
+Revision ID: f3c52d6c9b16
+Revises: 15b6b890ce1d
+Create Date: 2025-02-14 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "f3c52d6c9b16"
+down_revision = "15b6b890ce1d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("agendamento_visita") as batch_op:
+        batch_op.add_column(sa.Column("cliente_id", sa.Integer(), nullable=True))
+        batch_op.create_foreign_key(
+            "fk_agendamento_visita_cliente_id",
+            "cliente",
+            ["cliente_id"],
+            ["id"],
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("agendamento_visita") as batch_op:
+        batch_op.drop_constraint(
+            "fk_agendamento_visita_cliente_id",
+            type_="foreignkey",
+        )
+        batch_op.drop_column("cliente_id")

--- a/models.py
+++ b/models.py
@@ -1138,7 +1138,7 @@ class HorarioVisitacao(db.Model):
 
 
 class AgendamentoVisita(db.Model):
-    """Agendamento realizado por um professor para uma turma."""
+    """Agendamento de visita feito por um professor, opcionalmente vinculado a um cliente."""
 
     __tablename__ = "agendamento_visita"
 
@@ -1147,6 +1147,9 @@ class AgendamentoVisita(db.Model):
         db.Integer, db.ForeignKey("horario_visitacao.id"), nullable=False
     )
     professor_id = db.Column(db.Integer, db.ForeignKey("usuario.id"), nullable=False)
+    cliente_id = db.Column(
+        db.Integer, db.ForeignKey("cliente.id"), nullable=True
+    )
 
     # Informações da escola e turma
     escola_nome = db.Column(db.String(200), nullable=False)
@@ -1181,6 +1184,9 @@ class AgendamentoVisita(db.Model):
     professor = db.relationship(
         "Usuario", backref=db.backref("agendamentos_visitas", lazy=True)
     )
+    cliente = db.relationship(
+        "Cliente", backref=db.backref("agendamentos_visitas", lazy=True)
+    )
 
     def __init__(self, **kwargs):
         super(AgendamentoVisita, self).__init__(**kwargs)
@@ -1189,7 +1195,11 @@ class AgendamentoVisita(db.Model):
         self.qr_code_token = str(uuid.uuid4())
 
     def __repr__(self):
-        return f"<AgendamentoVisita {self.id} - Prof. {self.professor.nome} - {self.escola_nome}>"
+        cliente_nome = self.cliente.nome if self.cliente else "sem cliente"
+        return (
+            f"<AgendamentoVisita {self.id} - Prof. {self.professor.nome} - "
+            f"{self.escola_nome} ({cliente_nome})>"
+        )
 
 
 class AlunoVisitante(db.Model):

--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -1141,6 +1141,7 @@ def criar_agendamento():
                         agendamento = AgendamentoVisita(
                             horario_id=horario.id,
                             professor_id=current_user.id,
+                            cliente_id=current_user.cliente_id,
                             escola_nome=escola_nome,
                             turma=turma,
                             nivel_ensino=faixa_etaria,
@@ -2450,8 +2451,14 @@ def exportar_agendamentos_pdf():
     # Adaptar conforme necessário
     if current_user.tipo == 'admin':
         agendamentos = AgendamentoVisita.query.all()
+    elif current_user.tipo == 'cliente':
+        agendamentos = AgendamentoVisita.query.filter_by(
+            cliente_id=current_user.id
+        ).all()
     else:
-        agendamentos = AgendamentoVisita.query.filter_by(professor_id=current_user.id).all()
+        agendamentos = AgendamentoVisita.query.filter_by(
+            professor_id=current_user.id
+        ).all()
     
     # Dados da tabela
     data = [['ID', 'Escola', 'Professor', 'Data', 'Horário', 'Turma', 'Status']]
@@ -2503,8 +2510,14 @@ def exportar_agendamentos_csv():
     # Filtrar agendamentos (usar mesma lógica de filtragem da view)
     if current_user.tipo == 'admin':
         agendamentos = AgendamentoVisita.query.all()
+    elif current_user.tipo == 'cliente':
+        agendamentos = AgendamentoVisita.query.filter_by(
+            cliente_id=current_user.id
+        ).all()
     else:
-        agendamentos = AgendamentoVisita.query.filter_by(professor_id=current_user.id).all()
+        agendamentos = AgendamentoVisita.query.filter_by(
+            professor_id=current_user.id
+        ).all()
     
     # Criar o buffer de memória para o CSV
     output = StringIO()
@@ -2877,16 +2890,10 @@ def listar_agendamentos():
     query = AgendamentoVisita.query
 
     # Filtrar por tipo de usuário
-    if current_user.tipo == 'participante' or current_user.tipo == 'professor':
-        # Professores/participantes só veem seus próprios agendamentos
+    if current_user.tipo in ['participante', 'professor']:
         query = query.filter(AgendamentoVisita.professor_id == current_user.id)
     elif current_user.tipo == 'cliente':
-        # Clientes veem agendamentos relacionados a eles
-        # Aqui precisaria de uma lógica para filtrar por cliente, se aplicável
-        if current_user.id:
-            # Filtrar agendamentos relacionados ao cliente
-            # Esta lógica depende da sua estrutura de dados
-            pass
+        query = query.filter(AgendamentoVisita.cliente_id == current_user.id)
     
     # Filtros dos parâmetros da URL
     if data_inicio:
@@ -2909,9 +2916,7 @@ def listar_agendamentos():
         pass
     
     if cliente_id and current_user.tipo == 'admin':
-        # Se você relacionar agendamentos com clientes
-        # query = query.filter(AgendamentoVisita.cliente_id == cliente_id)
-        pass
+        query = query.filter(AgendamentoVisita.cliente_id == cliente_id)
     
     # Ordenação
     query = query.order_by(AgendamentoVisita.data_agendamento.desc())
@@ -3147,6 +3152,7 @@ def agendar_visita(horario_id):
         novo_agendamento = AgendamentoVisita(
             horario_id=horario.id,
             professor_id=current_user.id,
+            cliente_id=current_user.cliente_id,
             escola_nome=escola_nome,
             turma=turma,
             nivel_ensino=nivel_ensino,

--- a/routes/professor_routes.py
+++ b/routes/professor_routes.py
@@ -183,6 +183,7 @@ def criar_agendamento_professor(horario_id):
             agendamento = AgendamentoVisita(
                 horario_id=horario.id,
                 professor_id=current_user.id,
+                cliente_id=current_user.cliente_id,
                 escola_nome=escola_nome,
                 escola_codigo_inep=escola_codigo_inep,
                 turma=turma,
@@ -561,6 +562,7 @@ def criar_agendamento_participante(horario_id):
             agendamento = AgendamentoVisita(
                 horario_id=horario.id,
                 professor_id=current_user.id,
+                cliente_id=current_user.cliente_id,
                 escola_nome=escola_nome,
                 escola_codigo_inep=escola_codigo_inep,
                 turma=turma,

--- a/services/pdf_service.py
+++ b/services/pdf_service.py
@@ -2503,8 +2503,15 @@ def gerar_pdf_comprovante_agendamento(agendamento, horario, evento, salas, aluno
         caminho_pdf: Caminho onde o PDF será salvo
     """
     
-    # 1) Obter todos os agendamentos do professor para compor o relatório
-    agendamentos = AgendamentoVisita.query.filter_by(professor_id=agendamento.professor_id).all()
+    # 1) Obter agendamentos do professor ou do mesmo cliente para o relatório
+    from sqlalchemy import or_
+
+    agendamentos = AgendamentoVisita.query.filter(
+        or_(
+            AgendamentoVisita.professor_id == agendamento.professor_id,
+            AgendamentoVisita.cliente_id == agendamento.cliente_id,
+        )
+    ).all()
     
     # 2) Cria objeto PDF
     pdf = FPDF()


### PR DESCRIPTION
## Summary
- add optional `cliente_id` to `AgendamentoVisita` with SQLAlchemy relationship and repr
- include migration adding `cliente_id` column
- update agendamento and professor routes to handle `cliente_id` filtering and creation
- expand PDF service to consider `cliente_id`

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: BuildError: Could not build url for endpoint, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689bda3925bc83328541f1a17b70add8