### PR TITLE
Set agendamento initial status to pending

### DIFF
--- a/models.py
+++ b/models.py
@@ -1169,8 +1169,8 @@ class AgendamentoVisita(db.Model):
     data_agendamento = db.Column(db.DateTime, default=datetime.utcnow)
     data_cancelamento = db.Column(db.DateTime, nullable=True)
     status = db.Column(
-        db.String(20), default="confirmado"
-    )  # confirmado, cancelado, realizado
+        db.String(20), default="pendente"
+    )  # pendente, confirmado, cancelado, realizado
     checkin_realizado = db.Column(db.Boolean, default=False)
     data_checkin = db.Column(db.DateTime, nullable=True)
 

--- a/routes/dashboard_cliente.py
+++ b/routes/dashboard_cliente.py
@@ -156,7 +156,7 @@ def dashboard_cliente():
     ).filter(
         Evento.cliente_id == current_user.id,
         HorarioVisitacao.data == hoje,
-        AgendamentoVisita.status == 'confirmado'
+        AgendamentoVisita.status.in_(['pendente', 'confirmado'])
     ).order_by(
         HorarioVisitacao.horario_inicio
     ).all()
@@ -171,7 +171,7 @@ def dashboard_cliente():
         Evento.cliente_id == current_user.id,
         HorarioVisitacao.data > hoje,
         HorarioVisitacao.data <= data_limite,
-        AgendamentoVisita.status == 'confirmado'
+        AgendamentoVisita.status.in_(['pendente', 'confirmado'])
     ).order_by(
         HorarioVisitacao.data,
         HorarioVisitacao.horario_inicio
@@ -355,7 +355,7 @@ def dashboard_aba_agendamentos():
     ).filter(
         Evento.cliente_id == current_user.id,
         HorarioVisitacao.data == hoje,
-        AgendamentoVisita.status == 'confirmado'
+        AgendamentoVisita.status.in_(['pendente', 'confirmado'])
     ).order_by(
         HorarioVisitacao.horario_inicio
     ).all()
@@ -370,7 +370,7 @@ def dashboard_aba_agendamentos():
         Evento.cliente_id == current_user.id,
         HorarioVisitacao.data > hoje,
         HorarioVisitacao.data <= data_limite,
-        AgendamentoVisita.status == 'confirmado'
+        AgendamentoVisita.status.in_(['pendente', 'confirmado'])
     ).order_by(
         HorarioVisitacao.data,
         HorarioVisitacao.horario_inicio
@@ -439,7 +439,7 @@ def dashboard_aba_agendamentos_hoje():
     ).filter(
         Evento.cliente_id == current_user.id,
         HorarioVisitacao.data == hoje,
-        AgendamentoVisita.status == 'confirmado'
+        AgendamentoVisita.status.in_(['pendente', 'confirmado'])
     ).order_by(
         HorarioVisitacao.horario_inicio
     ).all()
@@ -468,7 +468,7 @@ def dashboard_aba_proximos_agendamentos():
         Evento.cliente_id == current_user.id,
         HorarioVisitacao.data > hoje,
         HorarioVisitacao.data <= data_limite,
-        AgendamentoVisita.status == 'confirmado'
+        AgendamentoVisita.status.in_(['pendente', 'confirmado'])
     ).order_by(
         HorarioVisitacao.data,
         HorarioVisitacao.horario_inicio
@@ -598,7 +598,7 @@ def set_dashboard_agendamentos_data():
     ).filter(
         Evento.cliente_id == current_user.id,
         HorarioVisitacao.data == hoje,
-        AgendamentoVisita.status == 'confirmado'
+        AgendamentoVisita.status.in_(['pendente', 'confirmado'])
     ).order_by(
         HorarioVisitacao.horario_inicio
     ).all()
@@ -613,7 +613,7 @@ def set_dashboard_agendamentos_data():
         Evento.cliente_id == current_user.id,
         HorarioVisitacao.data > hoje,
         HorarioVisitacao.data <= data_limite,
-        AgendamentoVisita.status == 'confirmado'
+        AgendamentoVisita.status.in_(['pendente', 'confirmado'])
     ).order_by(
         HorarioVisitacao.data,
         HorarioVisitacao.horario_inicio

--- a/templates/agendamento/detalhes_agendamentos.html
+++ b/templates/agendamento/detalhes_agendamentos.html
@@ -13,7 +13,9 @@
             <p><strong>Turma:</strong> {{ agendamento.turma }}</p>
             <p><strong>Quantidade de Alunos:</strong> {{ agendamento.quantidade_alunos }}</p>
             <p><strong>Status:</strong> 
-                {% if agendamento.status == 'confirmado' %}
+                {% if agendamento.status == 'pendente' %}
+                    <span class="badge bg-warning text-dark">Pendente</span>
+                {% elif agendamento.status == 'confirmado' %}
                     <span class="badge bg-success">Confirmado</span>
                 {% elif agendamento.status == 'realizado' %}
                     <span class="badge bg-info">Realizado</span>

--- a/templates/agendamento/listar_agendamentos.html
+++ b/templates/agendamento/listar_agendamentos.html
@@ -133,7 +133,7 @@
                       'realizado': 'primary'
                     } %}
                     {% set status_badge = status_badges.get(agendamento.status, 'secondary') %}
-                    <span class="badge bg-{{ status_badge }}">{{ agendamento.status }}</span>
+                    <span class="badge bg-{{ status_badge }}">{{ agendamento.status|capitalize }}</span>
                   </td>
                   <td class="text-center">
                       <div class="btn-group btn-group-sm">

--- a/templates/professor/meus_agendamentos.html
+++ b/templates/professor/meus_agendamentos.html
@@ -20,6 +20,7 @@
                         <div class="col-md-4">
                             <select name="status" class="form-select">
                                 <option value="">Todos os status</option>
+                                <option value="pendente" {% if status_filtro == 'pendente' %}selected{% endif %}>Pendentes</option>
                                 <option value="confirmado" {% if status_filtro == 'confirmado' %}selected{% endif %}>Confirmados</option>
                                 <option value="cancelado" {% if status_filtro == 'cancelado' %}selected{% endif %}>Cancelados</option>
                                 <option value="realizado" {% if status_filtro == 'realizado' %}selected{% endif %}>Realizados</option>
@@ -74,7 +75,9 @@
                                             <td>{{ agendamento.turma }}</td>
                                             <td>{{ agendamento.quantidade_alunos }}</td>
                                             <td>
-                                                {% if agendamento.status == 'confirmado' %}
+                                                {% if agendamento.status == 'pendente' %}
+                                                    <span class="badge rounded-pill bg-warning text-dark">Pendente</span>
+                                                {% elif agendamento.status == 'confirmado' %}
                                                     <span class="badge rounded-pill bg-primary">Confirmado</span>
                                                 {% elif agendamento.status == 'cancelado' %}
                                                     <span class="badge rounded-pill bg-danger">Cancelado</span>

--- a/tests/test_agendamento_flow.py
+++ b/tests/test_agendamento_flow.py
@@ -223,6 +223,7 @@ def test_fluxo_agendamento(app):
         agendamento = AgendamentoVisita.query.get(agendamento_id)
         assert agendamento.professor_id is not None
         assert agendamento.cliente_id is None
+        assert agendamento.status == 'pendente'
 
 
 def test_cliente_cria_agendamento(app):
@@ -250,6 +251,7 @@ def test_cliente_cria_agendamento(app):
         agendamento = AgendamentoVisita.query.first()
         assert agendamento.cliente_id is not None
         assert agendamento.professor_id is None
+        assert agendamento.status == 'pendente'
 
 
 def test_editar_agendamento_shows_current_when_full(app):

--- a/tests/test_checkin_routes.py
+++ b/tests/test_checkin_routes.py
@@ -154,9 +154,15 @@ def app():
         db.session.add(horario)
         db.session.commit()
 
-        agendamento = AgendamentoVisita(horario_id=horario.id, professor_id=professor.id,
-                                        escola_nome='Escola', turma='T1',
-                                        nivel_ensino='fundamental', quantidade_alunos=10)
+        agendamento = AgendamentoVisita(
+            horario_id=horario.id,
+            professor_id=professor.id,
+            escola_nome='Escola',
+            turma='T1',
+            nivel_ensino='fundamental',
+            quantidade_alunos=10,
+            status='confirmado'
+        )
         db.session.add(agendamento)
         db.session.commit()
 


### PR DESCRIPTION
## Summary
- default AgendamentoVisita.status to "pendente"
- include pending visits in capacity checks and dashboard listings
- show "Pendente" status in agendamento and professor templates
- ensure new agendamentos start pending in tests

## Testing
- `pytest` *(fails: BuildError and other missing template issues)*

------
https://chatgpt.com/codex/tasks/task_e_689be09da95c83328f328f34481b8e53