### PR TITLE
Remove duplicate date fields from form creation template

### DIFF
--- a/templates/formulario/criar_formulario.html
+++ b/templates/formulario/criar_formulario.html
@@ -35,20 +35,6 @@
                     </label>
                 </div>
 
-
-
-                <div class="mb-4">
-                    <label for="data_inicio" class="form-label fw-medium">Início</label>
-                    <input type="datetime-local" id="data_inicio" name="data_inicio" class="form-control">
-                </div>
-
-                <div class="mb-4">
-                    <label for="data_fim" class="form-label fw-medium">Fim</label>
-                    <input type="datetime-local" id="data_fim" name="data_fim" class="form-control">
-                </div>
-
-
-
                 <div class="mb-4">
                     <label for="data_inicio" class="form-label fw-medium">Data de Início</label>
                     <input type="datetime-local" id="data_inicio" name="data_inicio" class="form-control">


### PR DESCRIPTION
## Summary
- remove redundant Início/Fim inputs so form only asks for one start/end date pair

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: BuildError and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_689deb5cd8348332be5c0b89f76f0ff6