### PR TITLE
Allow DOC uploads in form routes

### DIFF
--- a/routes/formularios_routes.py
+++ b/routes/formularios_routes.py
@@ -46,7 +46,7 @@ from services.pdf_service import gerar_pdf_respostas
 logger = logging.getLogger(__name__)
 
 # Extensões permitidas (use com os.path.splitext, que retorna com ponto na extensão)
-ALLOWED_UPLOAD_EXTENSIONS = {".pdf", ".png", ".jpg", ".jpeg", ".gif"}
+ALLOWED_UPLOAD_EXTENSIONS = {".pdf", ".png", ".jpg", ".jpeg", ".gif", ".doc", ".docx"}
 
 formularios_routes = Blueprint(
     "formularios_routes", __name__, template_folder="../templates/formulario"


### PR DESCRIPTION
## Summary
- allow .doc and .docx files when uploading form attachments

## Testing
- `pytest` *(fails: BuildError in campo routes, IntegrityError in campo routes, 8 failed, 11 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689deb7fdcb48332b0f0dce47738eca1