### PR TITLE
Allow DOC uploads for revisor

### DIFF
--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -45,7 +45,7 @@ from models import (
 from services.pdf_service import gerar_revisor_details_pdf
 
 # Extensões permitidas para upload de arquivos
-ALLOWED_EXTENSIONS = {'.pdf', '.png', '.jpg', '.jpeg'}
+ALLOWED_EXTENSIONS = {'.pdf', '.png', '.jpg', '.jpeg', '.doc', '.docx'}
 
 # -----------------------------------------------------------------------------
 # Blueprint


### PR DESCRIPTION
## Summary
- allow DOC and DOCX files for revisor uploads

## Testing
- `pip install -r requirements-dev.txt`
- `pip install beautifulsoup4`
- `pytest` *(fails: tests/test_audit_log_resposta_deletion.py::test_delete_response_cascades_audit_logs, tests/test_campo_routes.py::test_remover_campo_personalizado_unauthorized)*

------
https://chatgpt.com/codex/tasks/task_e_689deb81761c833287cfe39d645e281e