### PR TITLE
Filter events in scheduling report by visit date range

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -336,10 +336,17 @@ def relatorio_geral_agendamentos():
     else:
         data_fim = datetime.utcnow().date()
     
-    # Buscar todos os eventos do cliente no período
-    eventos = Evento.query.filter_by(
-        cliente_id=current_user.id
-    ).all()
+    # Buscar eventos do cliente com horários dentro do período selecionado
+    eventos = (
+        Evento.query.join(HorarioVisitacao)
+        .filter(
+            Evento.cliente_id == current_user.id,
+            HorarioVisitacao.data >= data_inicio,
+            HorarioVisitacao.data <= data_fim,
+        )
+        .distinct()
+        .all()
+    )
     
     # Estatísticas gerais
     estatisticas = {}

--- a/tests/test_relatorio_geral_agendamentos.py
+++ b/tests/test_relatorio_geral_agendamentos.py
@@ -1,0 +1,177 @@
+import os
+import sys
+import types
+from datetime import date, time
+
+import pytest
+from werkzeug.security import generate_password_hash
+
+# --- Stubs de módulos externos ---
+utils_stub = types.ModuleType('utils')
+taxa_service = types.ModuleType('utils.taxa_service')
+taxa_service.calcular_taxa_cliente = lambda *a, **k: {
+    'taxa_aplicada': 0,
+    'usando_taxa_diferenciada': False
+}
+taxa_service.calcular_taxas_clientes = lambda *a, **k: []
+utils_stub.taxa_service = taxa_service
+utils_stub.preco_com_taxa = lambda *a, **k: 1
+utils_stub.obter_estados = lambda *a, **k: []
+utils_stub.external_url = lambda *a, **k: ''
+utils_stub.gerar_comprovante_pdf = lambda *a, **k: ''
+utils_stub.enviar_email = lambda *a, **k: None
+utils_stub.formatar_brasilia = lambda *a, **k: ''
+utils_stub.determinar_turno = lambda *a, **k: ''
+sys.modules.setdefault('utils', utils_stub)
+sys.modules.setdefault('utils.taxa_service', taxa_service)
+
+dia_semana_mod = types.ModuleType('utils.dia_semana')
+dia_semana_mod.dia_semana = lambda *a, **k: ''
+sys.modules.setdefault('utils.dia_semana', dia_semana_mod)
+utils_stub.dia_semana = dia_semana_mod
+
+utils_security = types.ModuleType('utils.security')
+utils_security.sanitize_input = lambda x: x
+utils_security.password_is_strong = lambda x: True
+sys.modules.setdefault('utils.security', utils_security)
+
+utils_mfa = types.ModuleType('utils.mfa')
+utils_mfa.mfa_required = lambda f: f
+sys.modules.setdefault('utils.mfa', utils_mfa)
+
+pdf_service_stub = types.ModuleType('services.pdf_service')
+pdf_service_stub.gerar_pdf_comprovante_agendamento = lambda *a, **k: ''
+pdf_service_stub.gerar_pdf_respostas = lambda *a, **k: None
+pdf_service_stub.gerar_comprovante_pdf = lambda *a, **k: ''
+pdf_service_stub.gerar_certificados_pdf = lambda *a, **k: ''
+pdf_service_stub.gerar_certificado_personalizado = lambda *a, **k: ''
+pdf_service_stub.gerar_pdf_inscritos_pdf = lambda *a, **k: ''
+pdf_service_stub.gerar_lista_frequencia_pdf = lambda *a, **k: ''
+pdf_service_stub.gerar_pdf_feedback = lambda *a, **k: ''
+pdf_service_stub.gerar_etiquetas = lambda *a, **k: None
+pdf_service_stub.gerar_lista_frequencia = lambda *a, **k: None
+pdf_service_stub.gerar_certificados = lambda *a, **k: None
+pdf_service_stub.gerar_evento_qrcode_pdf = lambda *a, **k: None
+pdf_service_stub.gerar_qrcode_token = lambda *a, **k: None
+pdf_service_stub.gerar_programacao_evento_pdf = lambda *a, **k: None
+pdf_service_stub.gerar_placas_oficinas_pdf = lambda *a, **k: None
+pdf_service_stub.exportar_checkins_pdf_opcoes = lambda *a, **k: None
+pdf_service_stub.gerar_revisor_details_pdf = lambda *a, **k: None
+sys.modules.setdefault('services.pdf_service', pdf_service_stub)
+
+arquivo_utils_stub = types.ModuleType('utils.arquivo_utils')
+arquivo_utils_stub.arquivo_permitido = lambda *a, **k: True
+sys.modules.setdefault('utils.arquivo_utils', arquivo_utils_stub)
+
+sys.modules.setdefault('pandas', types.ModuleType('pandas'))
+sys.modules.setdefault('qrcode', types.ModuleType('qrcode'))
+sys.modules.setdefault('openpyxl', types.ModuleType('openpyxl'))
+sys.modules['openpyxl'].Workbook = object
+
+pil_stub = types.ModuleType('PIL')
+pil_stub.Image = types.SimpleNamespace(new=lambda *a, **k: None, open=lambda *a, **k: None)
+pil_stub.ImageDraw = types.SimpleNamespace(Draw=lambda *a, **k: None)
+pil_stub.ImageFont = types.SimpleNamespace(truetype=lambda *a, **k: None)
+sys.modules.setdefault('PIL', pil_stub)
+
+sys.modules.setdefault('requests', types.ModuleType('requests'))
+sys.modules.setdefault('reportlab', types.ModuleType('reportlab'))
+sys.modules.setdefault('reportlab.lib', types.ModuleType('reportlab.lib'))
+sys.modules.setdefault('reportlab.lib.pagesizes', types.ModuleType('reportlab.lib.pagesizes'))
+sys.modules['reportlab.lib.pagesizes'].letter = None
+sys.modules['reportlab.lib.pagesizes'].landscape = None
+sys.modules['reportlab.lib.pagesizes'].A4 = None
+sys.modules.setdefault('reportlab.lib.units', types.ModuleType('reportlab.lib.units'))
+sys.modules['reportlab.lib.units'].inch = None
+sys.modules['reportlab.lib.units'].mm = None
+sys.modules.setdefault('reportlab.pdfgen', types.ModuleType('reportlab.pdfgen'))
+sys.modules.setdefault('reportlab.pdfgen.canvas', types.ModuleType('reportlab.pdfgen.canvas'))
+sys.modules.setdefault('reportlab.lib.colors', types.ModuleType('reportlab.lib.colors'))
+sys.modules.setdefault('reportlab.platypus', types.ModuleType('reportlab.platypus'))
+reportlab_platypus = sys.modules['reportlab.platypus']
+reportlab_platypus.SimpleDocTemplate = object
+reportlab_platypus.Table = object
+reportlab_platypus.TableStyle = object
+reportlab_platypus.Paragraph = object
+reportlab_platypus.Spacer = object
+sys.modules.setdefault('reportlab.lib.styles', types.ModuleType('reportlab.lib.styles'))
+sys.modules['reportlab.lib.styles'].getSampleStyleSheet = lambda: None
+
+os.environ.setdefault('GOOGLE_CLIENT_ID', 'x')
+os.environ.setdefault('GOOGLE_CLIENT_SECRET', 'x')
+os.environ.setdefault('SECRET_KEY', 'test')
+
+from config import Config
+
+Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(Config.SQLALCHEMY_DATABASE_URI)
+
+from app import create_app
+from extensions import db
+from models import Usuario, Cliente, Evento, HorarioVisitacao
+
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    with app.app_context():
+        db.create_all()
+        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('123'))
+        db.session.add(cliente)
+        db.session.commit()
+
+        Usuario(
+            id=cliente.id,
+            nome='CliUser',
+            cpf='1',
+            email='cli@test',
+            senha=generate_password_hash('123'),
+            formacao='x',
+            tipo='cliente'
+        )
+        db.session.commit()
+
+        evento1 = Evento(cliente_id=cliente.id, nome='Evento1')
+        evento2 = Evento(cliente_id=cliente.id, nome='Evento2')
+        db.session.add_all([evento1, evento2])
+        db.session.commit()
+
+        h1 = HorarioVisitacao(
+            evento_id=evento1.id,
+            data=date(2024, 1, 10),
+            horario_inicio=time(9, 0),
+            horario_fim=time(10, 0),
+            capacidade_total=30,
+            vagas_disponiveis=30,
+        )
+        h2 = HorarioVisitacao(
+            evento_id=evento2.id,
+            data=date(2024, 2, 10),
+            horario_inicio=time(9, 0),
+            horario_fim=time(10, 0),
+            capacidade_total=30,
+            vagas_disponiveis=30,
+        )
+        db.session.add_all([h1, h2])
+        db.session.commit()
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login(client):
+    return client.post('/login', data={'email': 'cli@test', 'senha': '123'})
+
+
+def test_relatorio_geral_agendamentos_filters_by_date(client):
+    login(client)
+    resp = client.get('/relatorio_geral_agendamentos?data_inicio=2024-01-01&data_fim=2024-01-31')
+    assert resp.status_code == 200
+    assert b'Evento1' in resp.data
+    assert b'Evento2' not in resp.data


### PR DESCRIPTION
## Summary
- filter events in general appointment report by associated visit dates
- add regression test ensuring events outside the date range are excluded

## Testing
- `pytest tests/test_relatorio_geral_agendamentos.py::test_relatorio_geral_agendamentos_filters_by_date -q`
- `pytest` *(fails: BuildError for missing routes and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_689dfcbcfe748332a05c6815c9ee54e1