### PR TITLE
Include pending visits in agendamento reports

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -373,6 +373,15 @@ def relatorio_geral_agendamentos():
             HorarioVisitacao.data >= data_inicio,
             HorarioVisitacao.data <= data_fim
         ).scalar() or 0
+
+        pendentes = db.session.query(func.count(AgendamentoVisita.id)).join(
+            HorarioVisitacao, AgendamentoVisita.horario_id == HorarioVisitacao.id
+        ).filter(
+            HorarioVisitacao.evento_id == evento.id,
+            AgendamentoVisita.status == 'pendente',
+            HorarioVisitacao.data >= data_inicio,
+            HorarioVisitacao.data <= data_fim
+        ).scalar() or 0
         
         # Total de visitantes
         visitantes = db.session.query(func.sum(AgendamentoVisita.quantidade_alunos)).join(
@@ -390,7 +399,8 @@ def relatorio_geral_agendamentos():
             'confirmados': confirmados,
             'realizados': realizados,
             'cancelados': cancelados,
-            'total': confirmados + realizados + cancelados,
+            'pendentes': pendentes,
+            'total': confirmados + realizados + cancelados + pendentes,
             'visitantes': visitantes
         }
     

--- a/templates/agendamento/relatorio_geral_agendamentos.html
+++ b/templates/agendamento/relatorio_geral_agendamentos.html
@@ -52,12 +52,14 @@
                     {% set total_confirmados = 0 %}
                     {% set total_realizados = 0 %}
                     {% set total_cancelados = 0 %}
+                    {% set total_pendentes = 0 %}
                     {% set total_visitantes = 0 %}
                     
                     {% for stats in estatisticas.values() %}
                         {% set total_confirmados = total_confirmados + stats.confirmados %}
                         {% set total_realizados = total_realizados + stats.realizados %}
                         {% set total_cancelados = total_cancelados + stats.cancelados %}
+                        {% set total_pendentes = total_pendentes + stats.pendentes %}
                         {% set total_visitantes = total_visitantes + stats.visitantes %}
                     {% endfor %}
                     
@@ -75,8 +77,12 @@
                             <span class="badge bg-danger rounded-pill">{{ total_cancelados }}</span>
                         </div>
                         <div class="list-group-item d-flex justify-content-between align-items-center">
+                            <span>Pendentes</span>
+                            <span class="badge bg-warning text-dark rounded-pill">{{ total_pendentes }}</span>
+                        </div>
+                        <div class="list-group-item d-flex justify-content-between align-items-center">
                             <span>Total de Agendamentos</span>
-                            <span class="badge bg-info rounded-pill">{{ total_confirmados + total_realizados + total_cancelados }}</span>
+                            <span class="badge bg-info rounded-pill">{{ total_confirmados + total_realizados + total_cancelados + total_pendentes }}</span>
                         </div>
                         <div class="list-group-item d-flex justify-content-between align-items-center">
                             <span>Total de Visitantes</span>
@@ -87,11 +93,12 @@
                     <div class="mt-3">
                         <h6>Distribuição de Status</h6>
                         <div class="progress" style="height: 25px;">
-                            {% set total = total_confirmados + total_realizados + total_cancelados %}
+                            {% set total = total_confirmados + total_realizados + total_cancelados + total_pendentes %}
                             {% if total > 0 %}
                                 {% set porcentagem_confirmados = (total_confirmados / total) * 100 %}
                                 {% set porcentagem_realizados = (total_realizados / total) * 100 %}
                                 {% set porcentagem_cancelados = (total_cancelados / total) * 100 %}
+                                {% set porcentagem_pendentes = (total_pendentes / total) * 100 %}
                                 
                                 <div class="progress-bar bg-primary" role="progressbar" style="width: {{ porcentagem_confirmados }}%;" title="Confirmados: {{ total_confirmados }}">
                                     {{ porcentagem_confirmados|round }}%
@@ -102,16 +109,20 @@
                                 <div class="progress-bar bg-danger" role="progressbar" style="width: {{ porcentagem_cancelados }}%;" title="Cancelados: {{ total_cancelados }}">
                                     {{ porcentagem_cancelados|round }}%
                                 </div>
+                                <div class="progress-bar bg-warning text-dark" role="progressbar" style="width: {{ porcentagem_pendentes }}%;" title="Pendentes: {{ total_pendentes }}">
+                                    {{ porcentagem_pendentes|round }}%
+                                </div>
                             {% else %}
                                 <div class="progress-bar" role="progressbar" style="width: 0%;">
                                     Sem dados
                                 </div>
                             {% endif %}
                         </div>
-                        <div class="d-flex justify-content-between mt-1 small">
+                        <div class="d-flex justify-content-between mt-1 small flex-wrap">
                             <span class="text-primary">Confirmados</span>
                             <span class="text-success">Realizados</span>
                             <span class="text-danger">Cancelados</span>
+                            <span class="text-warning">Pendentes</span>
                         </div>
                     </div>
                 </div>
@@ -133,6 +144,7 @@
                                         <th class="text-center">Confirmados</th>
                                         <th class="text-center">Realizados</th>
                                         <th class="text-center">Cancelados</th>
+                                        <th class="text-center">Pendentes</th>
                                         <th class="text-center">Visitantes</th>
                                         <th class="text-center">Taxa Conclusão</th>
                                     </tr>
@@ -144,6 +156,7 @@
                                             <td class="text-center">{{ stats.confirmados }}</td>
                                             <td class="text-center">{{ stats.realizados }}</td>
                                             <td class="text-center">{{ stats.cancelados }}</td>
+                                            <td class="text-center">{{ stats.pendentes }}</td>
                                             <td class="text-center">{{ stats.visitantes }}</td>
                                             <td class="text-center">
                                                 {% if stats.confirmados + stats.realizados > 0 %}
@@ -182,8 +195,9 @@
                 <div class="col-md-6">
                     <h5>Análise Geral</h5>
                     <ul>
-                        {% if total_confirmados + total_realizados + total_cancelados > 0 %}
-                            {% set taxa_cancelamento = (total_cancelados / (total_confirmados + total_realizados + total_cancelados)) * 100 %}
+                        {% if total_confirmados + total_realizados + total_cancelados + total_pendentes > 0 %}
+                            {% set total_ag = total_confirmados + total_realizados + total_cancelados + total_pendentes %}
+                            {% set taxa_cancelamento = (total_cancelados / total_ag) * 100 %}
                             <li>
                                 <strong>Taxa de Cancelamento:</strong> {{ taxa_cancelamento|round(1) }}%
                                 {% if taxa_cancelamento > 30 %}
@@ -211,7 +225,7 @@
                 <div class="col-md-6">
                     <h5>Recomendações</h5>
                     <ul>
-                        {% if total_confirmados + total_realizados + total_cancelados > 0 %}
+                        {% if total_confirmados + total_realizados + total_cancelados + total_pendentes > 0 %}
                             {% if taxa_cancelamento > 30 %}
                                 <li>Considere revisar suas políticas de cancelamento para reduzir a taxa de desistência.</li>
                                 <li>Envie lembretes com mais frequência para professores com agendamentos confirmados.</li>

--- a/tests/test_relatorio_geral_agendamentos.py
+++ b/tests/test_relatorio_geral_agendamentos.py
@@ -1,0 +1,186 @@
+import os
+import sys
+import types
+from datetime import date, time
+import contextlib
+
+import pytest
+from flask import template_rendered
+from werkzeug.security import generate_password_hash
+
+# Stubs for optional dependencies
+sys.modules.setdefault('pandas', types.ModuleType('pandas'))
+sys.modules.setdefault('qrcode', types.ModuleType('qrcode'))
+sys.modules.setdefault('openpyxl', types.ModuleType('openpyxl'))
+sys.modules['openpyxl'].Workbook = object
+sys.modules.setdefault('PIL', types.ModuleType('PIL'))
+sys.modules['PIL'].Image = types.SimpleNamespace(
+    new=lambda *a, **k: None, open=lambda *a, **k: None
+)
+sys.modules.setdefault('reportlab', types.ModuleType('reportlab'))
+sys.modules.setdefault('reportlab.lib', types.ModuleType('reportlab.lib'))
+sys.modules.setdefault('reportlab.lib.pagesizes',
+                       types.ModuleType('reportlab.lib.pagesizes'))
+rl_pages = sys.modules['reportlab.lib.pagesizes']
+rl_pages.letter = None
+rl_pages.landscape = None
+rl_pages.A4 = None
+sys.modules.setdefault('reportlab.lib.units',
+                       types.ModuleType('reportlab.lib.units'))
+rl_units = sys.modules['reportlab.lib.units']
+rl_units.inch = None
+rl_units.mm = None
+sys.modules.setdefault('reportlab.pdfgen', types.ModuleType('reportlab.pdfgen'))
+sys.modules.setdefault('reportlab.pdfgen.canvas',
+                       types.ModuleType('reportlab.pdfgen.canvas'))
+sys.modules.setdefault('reportlab.lib.colors',
+                       types.ModuleType('reportlab.lib.colors'))
+sys.modules.setdefault('reportlab.platypus',
+                       types.ModuleType('reportlab.platypus'))
+rl_plat = sys.modules['reportlab.platypus']
+rl_plat.SimpleDocTemplate = object
+rl_plat.Table = object
+rl_plat.TableStyle = object
+rl_plat.Paragraph = object
+rl_plat.Spacer = object
+rl_plat.Image = object
+sys.modules.setdefault('fpdf', types.ModuleType('fpdf'))
+sys.modules['fpdf'].FPDF = object
+
+pdf_service_stub = types.ModuleType('services.pdf_service')
+pdf_service_stub.gerar_pdf_comprovante_agendamento = lambda *a, **k: ''
+pdf_service_stub.gerar_pdf_respostas = lambda *a, **k: None
+pdf_service_stub.gerar_comprovante_pdf = lambda *a, **k: ''
+pdf_service_stub.gerar_certificados_pdf = lambda *a, **k: ''
+pdf_service_stub.gerar_certificado_personalizado = lambda *a, **k: ''
+pdf_service_stub.gerar_pdf_inscritos_pdf = lambda *a, **k: ''
+pdf_service_stub.gerar_lista_frequencia_pdf = lambda *a, **k: ''
+pdf_service_stub.gerar_pdf_feedback = lambda *a, **k: ''
+pdf_service_stub.gerar_etiquetas = lambda *a, **k: None
+pdf_service_stub.gerar_lista_frequencia = lambda *a, **k: None
+pdf_service_stub.gerar_certificados = lambda *a, **k: None
+pdf_service_stub.gerar_evento_qrcode_pdf = lambda *a, **k: None
+pdf_service_stub.gerar_qrcode_token = lambda *a, **k: None
+pdf_service_stub.gerar_programacao_evento_pdf = lambda *a, **k: None
+pdf_service_stub.gerar_placas_oficinas_pdf = lambda *a, **k: None
+pdf_service_stub.exportar_checkins_pdf_opcoes = lambda *a, **k: None
+pdf_service_stub.gerar_revisor_details_pdf = lambda *a, **k: None
+sys.modules.setdefault('services.pdf_service', pdf_service_stub)
+
+os.environ.setdefault('SECRET_KEY', 'test')
+os.environ.setdefault('GOOGLE_CLIENT_ID', 'x')
+os.environ.setdefault('GOOGLE_CLIENT_SECRET', 'x')
+
+from config import Config
+from app import create_app
+from extensions import db
+from models import Cliente, Evento, HorarioVisitacao, AgendamentoVisita
+
+Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(
+    Config.SQLALCHEMY_DATABASE_URI
+)
+
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    with app.app_context():
+        db.create_all()
+        cliente = Cliente(
+            nome='Cli', email='cli@test', senha=generate_password_hash('123')
+        )
+        db.session.add(cliente)
+        db.session.commit()
+        evento = Evento(cliente_id=cliente.id, nome='EV')
+        db.session.add(evento)
+        db.session.commit()
+        horario = HorarioVisitacao(
+            evento_id=evento.id,
+            data=date.today(),
+            horario_inicio=time(9, 0),
+            horario_fim=time(10, 0),
+            capacidade_total=100,
+            vagas_disponiveis=100,
+        )
+        db.session.add(horario)
+        db.session.commit()
+        ags = [
+            AgendamentoVisita(
+                horario_id=horario.id,
+                escola_nome='E1',
+                turma='T1',
+                nivel_ensino='1',
+                quantidade_alunos=10,
+                status='pendente',
+            ),
+            AgendamentoVisita(
+                horario_id=horario.id,
+                escola_nome='E2',
+                turma='T1',
+                nivel_ensino='1',
+                quantidade_alunos=10,
+                status='confirmado',
+            ),
+            AgendamentoVisita(
+                horario_id=horario.id,
+                escola_nome='E3',
+                turma='T1',
+                nivel_ensino='1',
+                quantidade_alunos=10,
+                status='realizado',
+            ),
+            AgendamentoVisita(
+                horario_id=horario.id,
+                escola_nome='E4',
+                turma='T1',
+                nivel_ensino='1',
+                quantidade_alunos=10,
+                status='cancelado',
+            ),
+        ]
+        db.session.add_all(ags)
+        db.session.commit()
+        app.evento_id = evento.id
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login(client):
+    return client.post(
+        '/login', data={'email': 'cli@test', 'senha': '123'}
+    )
+
+
+@contextlib.contextmanager
+def captured_templates(app):
+    recorded = []
+
+    def record(sender, template, context, **extra):
+        recorded.append((template, context))
+
+    template_rendered.connect(record, app)
+    try:
+        yield recorded
+    finally:
+        template_rendered.disconnect(record, app)
+
+
+def test_counts_all_statuses(client, app):
+    login(client)
+    with captured_templates(app) as templates:
+        resp = client.get('/relatorio_geral_agendamentos')
+    assert resp.status_code == 200
+    template, context = templates[0]
+    stats = context['estatisticas'][app.evento_id]
+    assert stats['pendentes'] == 1
+    assert stats['confirmados'] == 1
+    assert stats['realizados'] == 1
+    assert stats['cancelados'] == 1
+    assert stats['total'] == 4


### PR DESCRIPTION
## Summary
- count pending appointments in relatorio_geral_agendamentos
- show pending totals and progress in agendamento report template
- test report statistics include all visit statuses

## Testing
- `pytest tests/test_relatorio_geral_agendamentos.py -q`
- `pytest -q` *(fails: 26 failed, 23 passed, 121 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689dfcd932508332b0c04362b9fa525e