### PR TITLE
Gracefully handle invalid dates in agendamento report

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -322,17 +322,25 @@ def relatorio_geral_agendamentos():
         return redirect(url_for('dashboard_routes.dashboard'))
     
     # Filtros de data
-    data_inicio = request.args.get('data_inicio')
-    data_fim = request.args.get('data_fim')
-    
-    if data_inicio:
-        data_inicio = datetime.strptime(data_inicio, '%Y-%m-%d').date()
+    data_inicio_raw = request.args.get('data_inicio')
+    data_fim_raw = request.args.get('data_fim')
+
+    if data_inicio_raw:
+        try:
+            data_inicio = datetime.strptime(data_inicio_raw, '%Y-%m-%d').date()
+        except ValueError:
+            flash('Data inicial inválida. Usando intervalo padrão.', 'danger')
+            data_inicio = datetime.utcnow().date() - timedelta(days=30)
     else:
         # Padrão: último mês
         data_inicio = datetime.utcnow().date() - timedelta(days=30)
-    
-    if data_fim:
-        data_fim = datetime.strptime(data_fim, '%Y-%m-%d').date()
+
+    if data_fim_raw:
+        try:
+            data_fim = datetime.strptime(data_fim_raw, '%Y-%m-%d').date()
+        except ValueError:
+            flash('Data final inválida. Usando a data atual.', 'danger')
+            data_fim = datetime.utcnow().date()
     else:
         data_fim = datetime.utcnow().date()
     

--- a/tests/test_relatorio_geral_agendamentos_invalid_dates.py
+++ b/tests/test_relatorio_geral_agendamentos_invalid_dates.py
@@ -1,0 +1,71 @@
+import os
+import pytest
+from werkzeug.security import generate_password_hash
+
+os.environ.setdefault('GOOGLE_CLIENT_ID', 'x')
+os.environ.setdefault('GOOGLE_CLIENT_SECRET', 'y')
+os.environ.setdefault('SECRET_KEY', 'test')
+
+from config import Config
+from app import create_app
+from extensions import db
+from models import Cliente
+
+
+Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(Config.SQLALCHEMY_DATABASE_URI)
+
+
+@pytest.fixture
+def app():
+    os.environ.setdefault('GOOGLE_CLIENT_ID', 'x')
+    os.environ.setdefault('GOOGLE_CLIENT_SECRET', 'y')
+    os.environ.setdefault('SECRET_KEY', 'test')
+
+    import sys
+    sys.modules.pop('routes.agendamento_routes', None)
+    sys.modules.pop('routes.dashboard_routes', None)
+    app = create_app()
+    if 'dashboard_routes.dashboard_cliente' not in app.view_functions:
+        app.add_url_rule(
+            '/dashboard_cliente',
+            endpoint='dashboard_routes.dashboard_cliente',
+            view_func=lambda: ''
+        )
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    with app.app_context():
+        db.create_all()
+        cliente = Cliente(
+            nome='Cli',
+            email='cli@test',
+            senha=generate_password_hash('123'),
+        )
+        db.session.add(cliente)
+        db.session.commit()
+    yield app
+    with app.app_context():
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login(client):
+    return client.post('/login', data={'email': 'cli@test', 'senha': '123'})
+
+
+def test_invalid_start_date_defaults(client):
+    login(client)
+    resp = client.get('/relatorio_geral_agendamentos?data_inicio=bad-date', follow_redirects=True)
+    assert resp.status_code == 200
+    assert b'Data inicial inv' in resp.data
+
+
+def test_invalid_end_date_defaults(client):
+    login(client)
+    resp = client.get('/relatorio_geral_agendamentos?data_fim=bad-date', follow_redirects=True)
+    assert resp.status_code == 200
+    assert b'Data final inv' in resp.data


### PR DESCRIPTION
## Summary
- protect `relatorio_geral_agendamentos` against invalid date strings by flashing an error and falling back to safe defaults
- add regression tests ensuring invalid start/end dates no longer crash the report

## Testing
- `pip install -r requirements-dev.txt`
- `pip install beautifulsoup4`
- `pytest` *(fails: Could not build url for endpoint and other existing failures)*

------
https://chatgpt.com/codex/tasks/task_e_689dfcf501508332b232d38551a9266c