### PR TITLE
Allow participants to manage booking students

### DIFF
--- a/templates/participante/meus_agendamentos.html
+++ b/templates/participante/meus_agendamentos.html
@@ -71,6 +71,11 @@
                                             </td>
                                             <td>
                                                 <div class="d-flex flex-wrap justify-content-center gap-1">
+                                                    {% if agendamento.status in ['pendente', 'confirmado'] %}
+                                                        <a href="{{ url_for('routes.adicionar_alunos_agendamento', agendamento_id=agendamento.id) }}" class="btn btn-sm btn-outline-success" title="Adicionar alunos">
+                                                            <i class="fas fa-user-plus me-1"></i>Adicionar
+                                                        </a>
+                                                    {% endif %}
                                                     {% if agendamento.status == 'confirmado' %}
                                                         <a href="{{ url_for('agendamento_routes.cancelar_agendamento_participante', agendamento_id=agendamento.id) }}" class="btn btn-sm btn-outline-danger" title="Cancelar">
                                                             <i class="fas fa-times me-1"></i>Cancelar


### PR DESCRIPTION
## Summary
- Let participants add or remove students from their own bookings
- Provide participant-facing links to add students in their agenda view
- Test participant student management and access restrictions

## Testing
- `pip install -r requirements-dev.txt`
- `pip install beautifulsoup4`
- `pytest` *(fails: ModuleNotFoundError: No module named 'bs4'; BuildError; TemplateNotFound; etc.)*
- `pytest tests/test_agendamento_flow.py::test_participante_manage_alunos tests/test_agendamento_flow.py::test_participante_cannot_manage_alunos_de_outro -q`


------
https://chatgpt.com/codex/tasks/task_e_689e05698c548332bec8a4d9e0b4045a