### PR TITLE
Expand agendamento access roles

### DIFF
--- a/routes/professor_routes.py
+++ b/routes/professor_routes.py
@@ -429,18 +429,34 @@ def confirmacao_agendamento_professor(agendamento_id):
 @routes.route('/professor/imprimir_agendamento/<int:agendamento_id>')
 @login_required
 def imprimir_agendamento_professor(agendamento_id):
-    # Apenas participantes (professores) podem acessar
-    if current_user.tipo != 'professor':
-        flash('Acesso negado! Esta área é exclusiva para professores.', 'danger')
+    """Gera o comprovante de um agendamento."""
+
+    # Permitir acesso a professores, participantes, clientes e usuários
+    tipos_permitidos = {'professor', 'participante', 'cliente', 'usuario'}
+    if current_user.tipo not in tipos_permitidos:
+        flash(
+            'Acesso negado! Esta área é exclusiva para professores, '
+            'participantes, clientes e usuários.',
+            'danger',
+        )
         return redirect(url_for('dashboard_routes.dashboard'))
-    
+
     agendamento = AgendamentoVisita.query.get_or_404(agendamento_id)
-    
-    # Verificar se o agendamento pertence ao professor
-    if agendamento.professor_id != current_user.id:
+
+    # Validar propriedade conforme o tipo do usuário
+    if current_user.tipo == 'professor' and agendamento.professor_id != current_user.id:
         flash('Acesso negado! Este agendamento não pertence a você.', 'danger')
         return redirect(url_for('agendamento_routes.meus_agendamentos'))
-    
+    if (
+        current_user.tipo == 'cliente'
+        and agendamento.horario.evento.cliente_id != current_user.id
+    ):
+        flash(
+            'Acesso negado! Este agendamento não pertence ao seu evento.',
+            'danger',
+        )
+        return redirect(url_for('agendamento_routes.meus_agendamentos'))
+
     horario = agendamento.horario
     evento = horario.evento
     
@@ -469,18 +485,34 @@ def imprimir_agendamento_professor(agendamento_id):
 @routes.route('/professor/qrcode_agendamento/<int:agendamento_id>')
 @login_required
 def qrcode_agendamento_professor(agendamento_id):
-    # Apenas participantes (professores) podem acessar
-    if current_user.tipo != 'professor':
-        flash('Acesso negado! Esta área é exclusiva para professores.', 'danger')
+    """Exibe o QR Code de um agendamento."""
+
+    # Permitir acesso a professores, participantes, clientes e usuários
+    tipos_permitidos = {'professor', 'participante', 'cliente', 'usuario'}
+    if current_user.tipo not in tipos_permitidos:
+        flash(
+            'Acesso negado! Esta área é exclusiva para professores, '
+            'participantes, clientes e usuários.',
+            'danger',
+        )
         return redirect(url_for('dashboard_routes.dashboard'))
-    
+
     agendamento = AgendamentoVisita.query.get_or_404(agendamento_id)
-    
-    # Verificar se o agendamento pertence ao professor
-    if agendamento.professor_id != current_user.id:
+
+    # Validar propriedade conforme o tipo do usuário
+    if current_user.tipo == 'professor' and agendamento.professor_id != current_user.id:
         flash('Acesso negado! Este agendamento não pertence a você.', 'danger')
         return redirect(url_for('agendamento_routes.meus_agendamentos'))
-    
+    if (
+        current_user.tipo == 'cliente'
+        and agendamento.horario.evento.cliente_id != current_user.id
+    ):
+        flash(
+            'Acesso negado! Este agendamento não pertence ao seu evento.',
+            'danger',
+        )
+        return redirect(url_for('agendamento_routes.meus_agendamentos'))
+
     # Página que exibe o QR Code para check-in
     return render_template(
         'professor/qrcode_agendamento.html',

--- a/templates/professor/adicionar_alunos.html
+++ b/templates/professor/adicionar_alunos.html
@@ -1,5 +1,6 @@
 
 <!-- Template: professor/adicionar_alunos.html -->
+<!-- Acesso para professores, participantes, clientes e usuários -->
 {% extends 'base.html' %}
 
 {% block title %}Adicionar Alunos{% endblock %}

--- a/templates/professor/qrcode_agendamento.html
+++ b/templates/professor/qrcode_agendamento.html
@@ -1,5 +1,6 @@
 
 <!-- Template: professor/qrcode_agendamento.html -->
+<!-- Acesso para professores, participantes, clientes e usuários -->
 {% extends 'base.html' %}
 
 {% block title %}QR Code do Agendamento{% endblock %}
@@ -36,7 +37,7 @@
         </div>
         <div class="card-body text-center">
             <div class="mb-3">
-                <img src="{{ url_for('routes.gerar_qrcode_token', token=token) }}" class="img-fluid" alt="QR Code">
+                <img src="{{ url_for('routes.gerar_qrcode_token_route', token=token) }}" class="img-fluid" alt="QR Code">
             </div>
             
             <div class="alert alert-info">
@@ -50,21 +51,6 @@
             <i class="fas fa-print"></i> Imprimir Comprovante
         </a>
         <a href="{{ url_for('agendamento_routes.meus_agendamentos') }}" class="btn btn-secondary">
-            <i class="fas fa-chevron-left"></i> Voltar
-        </a>
-    </div>
-</div>
-{% endblock %} else %}
-        <div class="alert alert-warning">
-            <i class="fas fa-exclamation-triangle"></i> Não há eventos disponíveis para agendamento no momento.
-        </div>
-    {% endif %}
-    
-    <div class="mt-4">
-        <a href="{{ url_for('agendamento_routes.meus_agendamentos') }}" class="btn btn-primary">
-            <i class="fas fa-calendar-alt"></i> Meus Agendamentos
-        </a>
-        <a href="{{ url_for('dashboard_participante_routes.dashboard_participante') }}" class="btn btn-secondary">
             <i class="fas fa-chevron-left"></i> Voltar
         </a>
     </div>

--- a/tests/test_professor_routes_access.py
+++ b/tests/test_professor_routes_access.py
@@ -1,0 +1,158 @@
+import os
+from datetime import date, time
+
+import pytest
+from werkzeug.security import generate_password_hash
+
+os.environ.setdefault('GOOGLE_CLIENT_ID', 'x')
+os.environ.setdefault('GOOGLE_CLIENT_SECRET', 'x')
+os.environ.setdefault('SECRET_KEY', 'test')
+
+from config import Config
+
+Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(
+    Config.SQLALCHEMY_DATABASE_URI
+)
+
+from app import create_app
+from extensions import db
+from models import (
+    Usuario,
+    Cliente,
+    Evento,
+    HorarioVisitacao,
+    AgendamentoVisita,
+    AlunoVisitante,
+)
+from services import pdf_service
+
+
+@pytest.fixture
+def app(monkeypatch):
+    def dummy_pdf(agendamento, horario, evento, salas, alunos, pdf_path):
+        os.makedirs(os.path.dirname(pdf_path), exist_ok=True)
+        with open(pdf_path, 'wb') as fh:
+            fh.write(b'PDF')
+        return pdf_path
+
+    monkeypatch.setattr(
+        pdf_service, 'gerar_pdf_comprovante_agendamento', dummy_pdf
+    )
+
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    with app.app_context():
+        db.create_all()
+
+        cliente = Cliente(
+            nome='Cliente',
+            email='cli@test',
+            senha=generate_password_hash('123'),
+        )
+        db.session.add(cliente)
+
+        professor = Usuario(
+            nome='Prof',
+            cpf='1',
+            email='prof@test',
+            senha=generate_password_hash('123'),
+            formacao='x',
+            tipo='professor',
+        )
+        participante = Usuario(
+            nome='Part',
+            cpf='2',
+            email='part@test',
+            senha=generate_password_hash('123'),
+            formacao='x',
+            tipo='participante',
+        )
+        usuario = Usuario(
+            nome='User',
+            cpf='3',
+            email='user@test',
+            senha=generate_password_hash('123'),
+            formacao='x',
+            tipo='usuario',
+        )
+        db.session.add_all([professor, participante, usuario])
+        db.session.commit()
+
+        evento = Evento(cliente_id=cliente.id, nome='Evento')
+        db.session.add(evento)
+        db.session.commit()
+
+        horario = HorarioVisitacao(
+            evento_id=evento.id,
+            data=date.today(),
+            horario_inicio=time(10, 0),
+            horario_fim=time(11, 0),
+            capacidade_total=10,
+            vagas_disponiveis=10,
+        )
+        db.session.add(horario)
+        db.session.commit()
+
+        agendamento = AgendamentoVisita(
+            horario_id=horario.id,
+            professor_id=professor.id,
+            escola_nome='Escola',
+            turma='T1',
+            nivel_ensino='Fundamental',
+            quantidade_alunos=1,
+            qr_code_token='token123',
+        )
+        db.session.add(agendamento)
+        db.session.commit()
+
+        aluno = AlunoVisitante(agendamento_id=agendamento.id, nome='Aluno')
+        db.session.add(aluno)
+        db.session.commit()
+
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login(client, email):
+    return client.post(
+        '/login',
+        data={'email': email, 'senha': '123'},
+        follow_redirects=False,
+    )
+
+
+@pytest.mark.parametrize(
+    'email',
+    ['prof@test', 'part@test', 'cli@test', 'user@test'],
+)
+def test_imprimir_agendamento_access(app, client, email):
+    from models import AgendamentoVisita
+
+    login(client, email)
+    with app.app_context():
+        agendamento_id = AgendamentoVisita.query.first().id
+    resp = client.get(f'/professor/imprimir_agendamento/{agendamento_id}')
+    assert resp.status_code == 200
+    assert resp.data.startswith(b'PDF')
+
+
+@pytest.mark.parametrize(
+    'email',
+    ['prof@test', 'part@test', 'cli@test', 'user@test'],
+)
+def test_qrcode_agendamento_access(app, client, email):
+    from models import AgendamentoVisita
+
+    login(client, email)
+    with app.app_context():
+        agendamento_id = AgendamentoVisita.query.first().id
+    resp = client.get(f'/professor/qrcode_agendamento/{agendamento_id}')
+    assert resp.status_code == 200
+    assert b'QR Code do Agendamento' in resp.data


### PR DESCRIPTION
## Summary
- Allow professors, participants, clients and users to print and view QR codes for agendamentos
- Adjust property checks for professors and clients and update templates
- Add tests covering multi-profile access to agendamento print and QR code routes

## Testing
- `pytest tests/test_professor_routes_access.py`
- `pytest` *(fails: assert '<b>Alice</b>' == 'Alice', ...)*

------
https://chatgpt.com/codex/tasks/task_e_689e1b5eefd48332827ce48ca8e3fe29