### PR TITLE
Add reviewer assignment limit

### DIFF
--- a/migrations/versions/64f77f3899ea_add_max_trabalhos_por_revisor.py
+++ b/migrations/versions/64f77f3899ea_add_max_trabalhos_por_revisor.py
@@ -1,0 +1,32 @@
+"""add max_trabalhos_por_revisor
+
+Revision ID: 64f77f3899ea
+Revises: e4cb3d4630b1
+Create Date: 2025-08-14 22:45:28.829816
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '64f77f3899ea'
+down_revision = 'e4cb3d4630b1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "configuracao_cliente",
+        sa.Column(
+            "max_trabalhos_por_revisor",
+            sa.Integer(),
+            nullable=True,
+            server_default="5",
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("configuracao_cliente", "max_trabalhos_por_revisor")

--- a/models.py
+++ b/models.py
@@ -804,7 +804,7 @@ class ConfiguracaoCliente(db.Model):
     num_revisores_min = db.Column(db.Integer, default=1)
     num_revisores_max = db.Column(db.Integer, default=2)
     prazo_parecer_dias = db.Column(db.Integer, default=14)
-    max_trabalhos_por_revisor = db.Column(db.Integer, default=5)
+    max_trabalhos_por_revisor = db.Column(db.Integer, default=5, nullable=True)
 
     obrigatorio_nome = db.Column(db.Boolean, default=True)
     obrigatorio_cpf = db.Column(db.Boolean, default=True)


### PR DESCRIPTION
## Summary
- add migration for `max_trabalhos_por_revisor` on `configuracao_cliente`
- expose new field in `ConfiguracaoCliente` model

## Testing
- `flask --app app:create_app db upgrade 64f77f3899ea` *(fails: No support for ALTER of constraints in SQLite dialect)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'bs4'; followed by additional test failures after installation)*
- `flask --app app:create_app run`

------
https://chatgpt.com/codex/tasks/task_e_689e663f06208332961be7e23eb95723