### PR TITLE
Add spreadsheet import for work metadata

### DIFF
--- a/models.py
+++ b/models.py
@@ -1348,6 +1348,15 @@ class ApresentacaoTrabalho(db.Model):
     local = db.Column(db.String(100), nullable=True)
 
 
+class WorkMetadata(db.Model):
+    """Stores selected metadata from imported work spreadsheets."""
+
+    __tablename__ = "work_metadata"
+
+    id = db.Column(db.Integer, primary_key=True)
+    data = db.Column(db.JSON, nullable=False)
+
+
 class Pagamento(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     usuario_id = db.Column(db.Integer, db.ForeignKey("usuario.id"), nullable=False)

--- a/templates/trabalho/importar_trabalhos.html
+++ b/templates/trabalho/importar_trabalhos.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container mt-4">
+  <h3>Importar Trabalhos</h3>
+  <form method="POST" enctype="multipart/form-data">
+    {% if csrf_token is defined %}
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    {% endif %}
+    <div class="mb-3">
+      <input class="form-control" type="file" name="arquivo" accept=".xls,.xlsx" required>
+    </div>
+    <button class="btn btn-primary" type="submit">Enviar</button>
+  </form>
+</div>
+{% endblock %}

--- a/templates/trabalho/selecionar_colunas_trabalho.html
+++ b/templates/trabalho/selecionar_colunas_trabalho.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container mt-4">
+  <h3>Selecione colunas para importar</h3>
+  <form method="POST">
+    {% if csrf_token is defined %}
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    {% endif %}
+    <input type="hidden" name="data" value="{{ data_json }}">
+    {% for col in columns %}
+      <div class="form-check">
+        <input class="form-check-input" type="checkbox" name="columns" value="{{ col }}" id="col_{{ loop.index }}">
+        <label class="form-check-label" for="col_{{ loop.index }}">{{ col }}</label>
+      </div>
+    {% endfor %}
+    <button class="btn btn-success mt-3" type="submit">Importar</button>
+  </form>
+</div>
+{% endblock %}

--- a/tests/test_importar_trabalhos.py
+++ b/tests/test_importar_trabalhos.py
@@ -1,0 +1,63 @@
+import io
+import json
+import os
+import pandas as pd
+import pytest
+from extensions import db
+from models import WorkMetadata
+
+
+def make_excel():
+    df = pd.DataFrame({"titulo": ["T1"], "resumo": ["R1"], "extra": ["E1"]})
+    buffer = io.BytesIO()
+    with pd.ExcelWriter(buffer, engine="xlsxwriter") as writer:
+        df.to_excel(writer, index=False)
+    buffer.seek(0)
+    return buffer, df
+
+
+@pytest.fixture
+def app():
+    os.environ.setdefault("SECRET_KEY", "test")
+    os.environ.setdefault("GOOGLE_CLIENT_ID", "x")
+    os.environ.setdefault("GOOGLE_CLIENT_SECRET", "x")
+    os.environ.setdefault("DB_ONLINE", "sqlite:///:memory:")
+    from app import create_app
+
+    app = create_app()
+    app.config["TESTING"] = True
+    app.config["WTF_CSRF_ENABLED"] = False
+    app.config["LOGIN_DISABLED"] = True
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    with app.app_context():
+        db.create_all()
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def test_upload_and_persist(client, app):
+    excel, df = make_excel()
+    resp = client.post(
+        "/importar_trabalhos",
+        data={"arquivo": (excel, "dados.xlsx")},
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 200
+    assert b"titulo" in resp.data
+    assert b"resumo" in resp.data
+
+    data_json = df.to_dict(orient="records")
+    resp = client.post(
+        "/importar_trabalhos",
+        data={"columns": ["titulo", "resumo"], "data": json.dumps(data_json)},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    with app.app_context():
+        rows = WorkMetadata.query.all()
+        assert len(rows) == 1
+        assert rows[0].data == {"titulo": "T1", "resumo": "R1"}


### PR DESCRIPTION
## Summary
- add WorkMetadata model and import route
- render templates to upload spreadsheets and choose columns
- cover import flow with tests

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: ModuleNotFoundError: No module named 'bs4', plus additional failures)*
- `pytest tests/test_importar_trabalhos.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689e747c774c83328dccb9c2715405d4