### PR TITLE
Enable reviewer draw with configurable filters and limits

### DIFF
--- a/routes/dashboard_cliente.py
+++ b/routes/dashboard_cliente.py
@@ -248,6 +248,18 @@ def dashboard_cliente():
         .all()
     )
 
+    filtro_opcoes = {}
+    for cand in revisor_candidaturas_aprovadas:
+        for campo, valor in (cand.respostas or {}).items():
+            filtro_opcoes.setdefault(campo, set()).add(valor)
+
+    sorteio_config = {
+        "max_trabalhos": config_cliente.max_trabalhos_por_revisor or 1,
+        "revisores_por_trabalho": config_cliente.num_revisores_max,
+        "saved_filters": session.get("revisor_filters", {}),
+        "filter_options": {k: sorted(v) for k, v in filtro_opcoes.items()},
+    }
+
     return render_template(
         'dashboard_cliente.html',
         usuario=current_user,
@@ -275,6 +287,7 @@ def dashboard_cliente():
         reviewer_apps=reviewer_apps,
         revisor_candidaturas=revisor_candidaturas,
         revisor_candidaturas_aprovadas=revisor_candidaturas_aprovadas,
+        sorteio_config=sorteio_config,
     )
     
 def obter_configuracao_do_cliente(cliente_id):

--- a/routes/peer_review_routes.py
+++ b/routes/peer_review_routes.py
@@ -108,31 +108,15 @@ def assign_reviews():
 # ---------------------------------------------------------------------------
 # Atribuição por filtros para revisores aprovados
 # ---------------------------------------------------------------------------
-@peer_review_routes.route("/assign_by_filters", methods=["POST"])
-@login_required
-def assign_by_filters():
-    """Distribui submissões a revisores aprovados com base em filtros."""
-    if current_user.tipo not in ("cliente", "admin", "superadmin"):
-        flash("Acesso negado!", "danger")
-        return redirect(url_for("dashboard_routes.dashboard"))
-
-    data = request.get_json() or {}
-    filtros: dict = data.get("filters", {})
-    limite = data.get("limit")
-
-    usuario = Usuario.query.get(getattr(current_user, "id", None))
-    uid = usuario.id if usuario else None
-    cliente_id = getattr(current_user, "id", None)
-
-    config = ConfiguracaoCliente.query.filter_by(cliente_id=cliente_id).first()
-    if limite is None and config:
-        limite = config.max_trabalhos_por_revisor
-    if limite is None:
-        limite = 1
-
-    max_por_sub = config.num_revisores_max if config else 1
-    prazo_dias = config.prazo_parecer_dias if config else 14
-
+def assign_by_filters_logic(
+    cliente_id: int | None,
+    filtros: dict,
+    limite: int,
+    max_por_sub: int,
+    uid: int | None,
+    prazo_dias: int,
+):
+    """Core logic used to assign submissions to reviewers."""
     candidaturas = (
         RevisorCandidatura.query.join(
             RevisorProcess, RevisorCandidatura.process_id == RevisorProcess.id
@@ -169,6 +153,7 @@ def assign_by_filters():
     contagem_sub = {s.id: len(s.assignments) for s in elegiveis}
 
     criados = 0
+    distrib = []
     for reviewer in reviewers:
         while contagem_revisor[reviewer.id] < limite and elegiveis:
             random.shuffle(elegiveis)
@@ -193,6 +178,7 @@ def assign_by_filters():
                     )
                 )
                 criados += 1
+                distrib.append({"submission_id": sub.id, "reviewer_id": reviewer.id})
                 contagem_revisor[reviewer.id] += 1
                 contagem_sub[sub.id] += 1
                 if contagem_sub[sub.id] >= max_por_sub:
@@ -203,7 +189,39 @@ def assign_by_filters():
                 break
 
     db.session.commit()
-    return {"success": True, "assignments": criados}
+    return {"success": True, "assignments": criados, "distribuicoes": distrib}
+
+
+@peer_review_routes.route("/assign_by_filters", methods=["POST"])
+@login_required
+def assign_by_filters():
+    """Distribui submissões a revisores aprovados com base em filtros."""
+    if current_user.tipo not in ("cliente", "admin", "superadmin"):
+        flash("Acesso negado!", "danger")
+        return redirect(url_for("dashboard_routes.dashboard"))
+
+    data = request.get_json() or {}
+    filtros: dict = data.get("filters", {})
+    limite = data.get("limit")
+    max_por_sub = data.get("max_per_submission")
+
+    usuario = Usuario.query.get(getattr(current_user, "id", None))
+    uid = usuario.id if usuario else None
+    cliente_id = getattr(current_user, "id", None)
+
+    config = ConfiguracaoCliente.query.filter_by(cliente_id=cliente_id).first()
+    if limite is None and config:
+        limite = config.max_trabalhos_por_revisor
+    if limite is None:
+        limite = 1
+    if max_por_sub is None and config:
+        max_por_sub = config.num_revisores_max
+    if max_por_sub is None:
+        max_por_sub = 1
+
+    prazo_dias = config.prazo_parecer_dias if config else 14
+    return assign_by_filters_logic(cliente_id, filtros, limite, max_por_sub, uid, prazo_dias)
+
 
 
 # ---------------------------------------------------------------------------

--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -44,6 +44,7 @@ from models import (
 )
 from tasks import send_email_task
 from services.pdf_service import gerar_revisor_details_pdf
+from .peer_review_routes import assign_by_filters_logic
 
 # Extensões permitidas para upload de arquivos
 ALLOWED_EXTENSIONS = {'.pdf', '.png', '.jpg', '.jpeg', '.doc', '.docx'}
@@ -374,6 +375,40 @@ def view_candidatura(cand_id: int):
 
     cand: RevisorCandidatura = RevisorCandidatura.query.get_or_404(cand_id)
     return render_template("revisor/candidatura_detail.html", candidatura=cand)
+
+
+# -----------------------------------------------------------------------------
+# SORTEIO DE REVISORES
+# -----------------------------------------------------------------------------
+@revisor_routes.route("/revisores/sortear", methods=["POST"])
+@login_required
+def sortear_revisores():
+    """Realiza sorteio de revisores aprovados com filtros e limites."""
+    if current_user.tipo != "cliente":  # type: ignore[attr-defined]
+        flash("Acesso negado!", "danger")
+        return redirect(url_for("dashboard_routes.dashboard"))
+
+    data = request.get_json() or {}
+    filtros = data.get("filters", {})
+    limite = data.get("limit")
+    max_por_sub = data.get("max_per_submission")
+
+    usuario = Usuario.query.get(getattr(current_user, "id", None))
+    uid = usuario.id if usuario else None
+    cliente_id = getattr(current_user, "id", None)
+
+    config = ConfiguracaoCliente.query.filter_by(cliente_id=cliente_id).first()
+    if limite is None and config:
+        limite = config.max_trabalhos_por_revisor
+    if max_por_sub is None and config:
+        max_por_sub = config.num_revisores_max
+    prazo_dias = config.prazo_parecer_dias if config else 14
+
+    session["revisor_filters"] = filtros
+    result = assign_by_filters_logic(
+        cliente_id, filtros, limite or 1, max_por_sub or 1, uid, prazo_dias
+    )
+    return jsonify(result)
 
 
 # -----------------------------------------------------------------------------

--- a/templates/dashboard/dashboard_cliente.html
+++ b/templates/dashboard/dashboard_cliente.html
@@ -1569,6 +1569,35 @@
         {% endfor %}
       </tbody>
     </table>
+
+    <h5 class="fw-bold mt-4">Sorteio de Revisores</h5>
+    <form id="sorteioRevisoresForm" class="mb-3">
+      <div class="row g-2">
+        <div class="col-md-4">
+          <label class="form-label">Máx. trabalhos por revisor</label>
+          <input type="number" min="1" name="limit" class="form-control" value="{{ sorteio_config.max_trabalhos }}">
+        </div>
+        <div class="col-md-4">
+          <label class="form-label">Revisores por trabalho</label>
+          <input type="number" min="1" name="max_per_submission" class="form-control" value="{{ sorteio_config.revisores_por_trabalho }}">
+        </div>
+      </div>
+      <div class="row g-2 mt-2">
+        {% for campo, valores in sorteio_config.filter_options.items() %}
+        <div class="col-md-4">
+          <label class="form-label">{{ campo }}</label>
+          <select class="form-select" name="filters[{{ campo }}]">
+            <option value=""></option>
+            {% for valor in valores %}
+            <option value="{{ valor }}" {% if sorteio_config.saved_filters.get(campo) == valor %}selected{% endif %}>{{ valor }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        {% endfor %}
+      </div>
+      <button type="submit" class="btn btn-primary mt-3">Sortear</button>
+    </form>
+    <div id="resultadoSorteio"></div>
   </div>
   <!-- /ABA 6: REVISORES -->
 <!-- Mantendo a integração com o script original sem modificações -->
@@ -1625,6 +1654,43 @@
         const text = row.innerText.toLowerCase();
         row.style.display = text.includes(term) ? '' : 'none';
       });
+    });
+  }
+
+  const formSorteio = document.getElementById('sorteioRevisoresForm');
+  if (formSorteio) {
+    formSorteio.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const formData = new FormData(formSorteio);
+      const payload = {
+        limit: parseInt(formData.get('limit'), 10),
+        max_per_submission: parseInt(formData.get('max_per_submission'), 10),
+        filters: {}
+      };
+      for (const [key, value] of formData.entries()) {
+        if (key.startsWith('filters[') && value) {
+          const campo = key.slice(8, -1);
+          payload.filters[campo] = value;
+        }
+      }
+      const resp = await fetch('{{ url_for('revisor_routes.sortear_revisores') }}', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      const json = await resp.json();
+      const container = document.getElementById('resultadoSorteio');
+      if (json.success) {
+        let list = '';
+        if (json.distribuicoes) {
+          list = '<ul class="list-group mt-2">' +
+            json.distribuicoes.map(d => `<li class="list-group-item">Trabalho ${d.submission_id} → Revisor ${d.reviewer_id}</li>`).join('') +
+            '</ul>';
+        }
+        container.innerHTML = `<div class="alert alert-success">Distribuições: ${json.assignments}</div>` + list;
+      } else {
+        container.innerHTML = `<div class="alert alert-warning">${json.message || 'Nenhum sorteio realizado'}</div>`;
+      }
     });
   }
 </script>

--- a/tests/test_sortear_revisores.py
+++ b/tests/test_sortear_revisores.py
@@ -1,0 +1,116 @@
+import os
+os.environ.setdefault('SECRET_KEY', 'test')
+os.environ.setdefault('GOOGLE_CLIENT_ID', 'x')
+os.environ.setdefault('GOOGLE_CLIENT_SECRET', 'y')
+from werkzeug.security import generate_password_hash
+import pytest
+from config import Config
+
+Config.SQLALCHEMY_DATABASE_URI = 'sqlite://'
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(
+    Config.SQLALCHEMY_DATABASE_URI
+)
+
+from app import create_app
+from extensions import db
+from models import (
+    Cliente,
+    ConfiguracaoCliente,
+    RevisorProcess,
+    RevisorCandidatura,
+    Submission,
+    Usuario,
+    Assignment,
+)
+
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    with app.app_context():
+        db.create_all()
+        cliente = Cliente(
+            nome='Cli',
+            email='cli@example.com',
+            senha=generate_password_hash('123'),
+        )
+        db.session.add(cliente)
+        db.session.commit()
+        db.session.add(
+            ConfiguracaoCliente(
+                cliente_id=cliente.id,
+                max_trabalhos_por_revisor=2,
+                num_revisores_max=1,
+            )
+        )
+        proc = RevisorProcess(cliente_id=cliente.id)
+        db.session.add(proc)
+        db.session.flush()
+        db.session.add(
+            RevisorCandidatura(
+                process_id=proc.id,
+                status='aprovado',
+                email='rev1@example.com',
+                respostas={'area': 'bio'},
+            )
+        )
+        db.session.add(
+            RevisorCandidatura(
+                process_id=proc.id,
+                status='aprovado',
+                email='rev2@example.com',
+                respostas={'area': 'bio'},
+            )
+        )
+        db.session.add(
+            Usuario(
+                nome='Rev1',
+                cpf='1',
+                email='rev1@example.com',
+                senha=generate_password_hash('123'),
+                formacao='',
+                tipo='revisor',
+            )
+        )
+        db.session.add(
+            Usuario(
+                nome='Rev2',
+                cpf='2',
+                email='rev2@example.com',
+                senha=generate_password_hash('123'),
+                formacao='',
+                tipo='revisor',
+            )
+        )
+        db.session.add(Submission(title='S1', code_hash='h1'))
+        db.session.add(Submission(title='S2', code_hash='h2'))
+        db.session.commit()
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login(client, email, senha):
+    return client.post('/login', data={'email': email, 'senha': senha}, follow_redirects=True)
+
+
+def test_sortear_revisores_limits(client, app):
+    login(client, 'cli@example.com', '123')
+    resp = client.post(
+        '/revisores/sortear',
+        json={'filters': {'area': 'bio'}, 'limit': 1, 'max_per_submission': 1},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['success']
+    with app.app_context():
+        assert Assignment.query.count() == 2
+        for r in Usuario.query.filter(Usuario.email.like('rev%')).all():
+            assert Assignment.query.filter_by(reviewer_id=r.id).count() <= 1
+        for s in Submission.query.all():
+            assert Assignment.query.filter_by(submission_id=s.id).count() <= 1


### PR DESCRIPTION
## Summary
- expose reviewer assignment settings and filter options on client dashboard
- add `/revisores/sortear` endpoint that delegates to existing filter-based assignment logic
- cover reviewer draw respecting per-reviewer and per-submission limits

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: Module errors and routing issues)*

------
https://chatgpt.com/codex/tasks/task_e_689e7491801c8332b6a0bef7906e8de8