### PR TITLE
Group models imports in inscricao_routes

### DIFF
--- a/routes/inscricao_routes.py
+++ b/routes/inscricao_routes.py
@@ -6,11 +6,28 @@ from werkzeug.security import generate_password_hash, check_password_hash
 from werkzeug.utils import secure_filename
 from datetime import datetime
 
-    Evento, Oficina, Inscricao, Usuario, LinkCadastro,
-    LoteInscricao, EventoInscricaoTipo, LoteTipoInscricao,
-    CampoPersonalizadoCadastro, RespostaCampo, RespostaFormulario, Formulario, RegraInscricaoEvento,
-    Patrocinador, Ministrante, InscricaoTipo, ConfiguracaoCliente, ConfiguracaoEvento, Cliente
+from models import (
+    Evento,
+    Oficina,
+    Inscricao,
+    Usuario,
+    LinkCadastro,
+    LoteInscricao,
+    EventoInscricaoTipo,
+    LoteTipoInscricao,
+    CampoPersonalizadoCadastro,
+    RespostaCampo,
+    RespostaFormulario,
+    Formulario,
+    RegraInscricaoEvento,
+    Patrocinador,
+    Ministrante,
+    InscricaoTipo,
+    ConfiguracaoCliente,
+    ConfiguracaoEvento,
+    Cliente,
 )
+
 import os
 from mp_fix_patch import fix_mp_notification_url, create_mp_preference
 import uuid


### PR DESCRIPTION
## Summary
- group model imports in inscricao_routes for clarity

## Testing
- `pytest` *(fails: 32 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a49fc15438833283a41253368039c0