### PR TITLE
Fix models import block in formularios routes

### DIFF
--- a/routes/formularios_routes.py
+++ b/routes/formularios_routes.py
@@ -23,9 +23,8 @@ from sqlalchemy import text, or_
 
 from sqlalchemy.exc import IntegrityError, ProgrammingError, SQLAlchemyError
 
-
 from extensions import db
-
+from models import (
     Formulario,
     RespostaFormulario,
     RespostaCampo,


### PR DESCRIPTION
## Summary
- wrap model imports in `formularios_routes` with `from models import`

## Testing
- `pytest` *(fails: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a5dafe5c8332a66115a185719490