### PR TITLE
Restrict check-in to owner or admin

### DIFF
--- a/routes/checkin_routes.py
+++ b/routes/checkin_routes.py
@@ -1,17 +1,33 @@
-from flask import Blueprint, render_template, request, redirect, url_for, flash, jsonify, session
+from flask import (
+    Blueprint,
+    render_template,
+    request,
+    redirect,
+    url_for,
+    flash,
+    jsonify,
+    session,
+)
 from flask_login import login_required, current_user
 from extensions import db, socketio
 from werkzeug.utils import secure_filename
 from datetime import datetime
 import logging
 
-logger = logging.getLogger(__name__)
-
-    Checkin, Inscricao, Oficina, ConfiguracaoCliente, ConfiguracaoEvento,
-    AgendamentoVisita, Evento, Usuario
+from models import (
+    Checkin,
+    Inscricao,
+    Oficina,
+    ConfiguracaoCliente,
+    ConfiguracaoEvento,
+    AgendamentoVisita,
+    Evento,
+    Usuario,
 )
 from utils import formatar_brasilia, determinar_turno
 from .agendamento_routes import agendamento_routes  # Needed for URL generation
+
+logger = logging.getLogger(__name__)
 
 checkin_routes = Blueprint('checkin_routes', __name__)
 
@@ -19,6 +35,7 @@ checkin_routes = Blueprint('checkin_routes', __name__)
 @checkin_routes.route('/leitor_checkin', methods=['GET'])
 @login_required
 def leitor_checkin():
+    """Realiza check-in com base no token fornecido."""
     logger.debug("Entrou em /leitor_checkin")
 
     token = request.args.get('token')
@@ -42,6 +59,34 @@ def leitor_checkin():
             return jsonify({'status': 'erro', 'mensagem': mensagem}), 404
         flash(mensagem, "danger")
         return redirect(url_for('dashboard_routes.dashboard'))
+
+    if inscricao.oficina_id:
+        cliente_id_associado = inscricao.oficina.cliente_id
+    elif inscricao.evento_id:
+        cliente_id_associado = inscricao.evento.cliente_id
+    else:
+        cliente_id_associado = None
+
+    is_admin = getattr(current_user, "is_admin", False)
+    is_super = getattr(current_user, "is_superuser", False)
+    if callable(is_super):
+        is_super = is_super()
+
+    if (
+        cliente_id_associado is not None
+        and current_user.id != cliente_id_associado
+        and not (is_admin or is_super)
+    ):
+        mensagem = "Você não tem permissão para realizar check-in."
+        logger.warning(
+            "Usuário %s não autorizado para check-in do cliente %s",
+            current_user.id,
+            cliente_id_associado,
+        )
+        if request.headers.get("X-Requested-With") == "XMLHttpRequest":
+            return jsonify({"status": "erro", "mensagem": mensagem}), 403
+        flash(mensagem, "danger")
+        return redirect(url_for("dashboard_routes.dashboard"))
 
     # Verifica se é check-in de oficina ou evento (prioriza oficina)
     if inscricao.oficina_id:

--- a/tests/test_checkin_routes.py
+++ b/tests/test_checkin_routes.py
@@ -10,6 +10,7 @@ os.environ.setdefault('GOOGLE_CLIENT_ID', 'x')
 os.environ.setdefault('GOOGLE_CLIENT_SECRET', 'x')
 
 utils_stub = types.ModuleType('utils')
+utils_stub.__path__ = []
 taxa_service = types.ModuleType('utils.taxa_service')
 taxa_service.calcular_taxa_cliente = lambda *a, **k: {
     'taxa_aplicada': 0,
@@ -26,6 +27,9 @@ utils_stub.formatar_brasilia = lambda *a, **k: ''
 utils_stub.determinar_turno = lambda *a, **k: ''
 sys.modules.setdefault('utils', utils_stub)
 sys.modules.setdefault('utils.taxa_service', taxa_service)
+dia_semana_stub = types.ModuleType('utils.dia_semana')
+dia_semana_stub.dia_semana = lambda *a, **k: ''
+sys.modules.setdefault('utils.dia_semana', dia_semana_stub)
 utils_security = types.ModuleType('utils.security')
 utils_security.sanitize_input = lambda x: x
 utils_security.password_is_strong = lambda x: True
@@ -59,6 +63,9 @@ sys.modules.setdefault('pandas', types.ModuleType('pandas'))
 sys.modules.setdefault('qrcode', types.ModuleType('qrcode'))
 sys.modules.setdefault('openpyxl', types.ModuleType('openpyxl'))
 sys.modules['openpyxl'].Workbook = object
+agendamento_stub = types.ModuleType('routes.agendamento_routes')
+agendamento_stub.agendamento_routes = object()
+sys.modules.setdefault('routes.agendamento_routes', agendamento_stub)
 pil_stub = types.ModuleType('PIL')
 pil_stub.Image = types.SimpleNamespace(new=lambda *a, **k: None, open=lambda *a, **k: None)
 pil_stub.ImageDraw = types.SimpleNamespace(Draw=lambda *a, **k: None)
@@ -94,8 +101,13 @@ from app import create_app
 from extensions import db
 from models import Evento, Oficina, Inscricao
 from models.user import Cliente, Usuario, Ministrante
-                    ConfiguracaoCliente, HorarioVisitacao, AgendamentoVisita,
-                    AlunoVisitante, Checkin)
+from models.event import (
+    ConfiguracaoCliente,
+    HorarioVisitacao,
+    AgendamentoVisita,
+    AlunoVisitante,
+    Checkin,
+)
 
 @pytest.fixture
 def app():
@@ -340,3 +352,67 @@ def test_leitor_checkin_json_other_client_denied(client, app):
     assert resp.status_code == 403
     data = resp.get_json()
     assert data['status'] == 'error'
+
+
+def test_leitor_checkin_html_success(client, app):
+    with app.app_context():
+        token = (
+            Inscricao.query.filter(Inscricao.evento_id.isnot(None))
+            .first()
+            .qr_code_token
+        )
+        participante = Usuario.query.filter_by(email='part@test').first()
+        evento = Evento.query.first()
+    login(client, 'cli@test', '123')
+    resp = client.get('/leitor_checkin', query_string={'token': token})
+    assert resp.status_code == 302
+    with app.app_context():
+        assert (
+            Checkin.query.filter_by(
+                usuario_id=participante.id, evento_id=evento.id
+            ).count()
+            == 1
+        )
+
+
+def test_leitor_checkin_html_other_client_denied(client, app):
+    with app.app_context():
+        other = Cliente(
+            nome='Other',
+            email='otherhtml@test',
+            senha=generate_password_hash('123'),
+        )
+        db.session.add(other)
+        db.session.commit()
+
+        evento = Evento(
+            cliente_id=other.id,
+            nome='E2',
+            habilitar_lotes=False,
+            inscricao_gratuita=True,
+        )
+        db.session.add(evento)
+        db.session.commit()
+
+        participante = Usuario.query.filter_by(email='part@test').first()
+        insc = Inscricao(
+            usuario_id=participante.id,
+            cliente_id=other.id,
+            evento_id=evento.id,
+            status_pagamento='approved',
+        )
+        db.session.add(insc)
+        db.session.commit()
+        token = insc.qr_code_token
+
+    login(client, 'cli@test', '123')
+    resp = client.get(
+        '/leitor_checkin',
+        query_string={'token': token},
+        headers={'X-Requested-With': 'XMLHttpRequest'},
+    )
+    assert resp.status_code == 403
+    data = resp.get_json()
+    assert data['status'] in ('erro', 'error')
+    with app.app_context():
+        assert Checkin.query.filter_by(evento_id=evento.id).count() == 0


### PR DESCRIPTION
## Summary
- require check-in operator to own the event or be admin in `leitor_checkin`
- add tests covering authorized and unauthorized check-in attempts

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError/ImportError in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c61b8c94833292e5e6e0e92ac779