### PR TITLE
Redirect unauthorized check-in listings

### DIFF
--- a/routes/checkin_routes.py
+++ b/routes/checkin_routes.py
@@ -6,9 +6,15 @@ from datetime import datetime
 import logging
 
 logger = logging.getLogger(__name__)
-
-    Checkin, Inscricao, Oficina, ConfiguracaoCliente, ConfiguracaoEvento,
-    AgendamentoVisita, Evento, Usuario
+from models import (
+    Checkin,
+    Inscricao,
+    Oficina,
+    ConfiguracaoCliente,
+    ConfiguracaoEvento,
+    AgendamentoVisita,
+    Evento,
+    Usuario,
 )
 from utils import formatar_brasilia, determinar_turno
 from .agendamento_routes import agendamento_routes  # Needed for URL generation
@@ -209,8 +215,9 @@ def checkin(oficina_id):
 @checkin_routes.route('/oficina/<int:oficina_id>/checkins', methods=['GET'])
 @login_required
 def lista_checkins(oficina_id):
-    if current_user.tipo not in ['admin', 'cliente']:
-        flash("Acesso Autorizado!", "danger")
+    if current_user.tipo not in ["admin", "cliente"]:
+        flash("Acesso não autorizado", "danger")
+        return redirect(url_for("dashboard_routes.dashboard"))
 
     oficina = Oficina.query.get_or_404(oficina_id)
     checkins = Checkin.query.filter_by(oficina_id=oficina_id).all()

--- a/tests/test_checkin_routes.py
+++ b/tests/test_checkin_routes.py
@@ -93,9 +93,16 @@ Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(Config.SQLALCHEMY
 from app import create_app
 from extensions import db
 from models import Evento, Oficina, Inscricao
-from models.user import Cliente, Usuario, Ministrante
-                    ConfiguracaoCliente, HorarioVisitacao, AgendamentoVisita,
-                    AlunoVisitante, Checkin)
+from models.user import (
+    Cliente,
+    Usuario,
+    Ministrante,
+    ConfiguracaoCliente,
+    HorarioVisitacao,
+    AgendamentoVisita,
+    AlunoVisitante,
+    Checkin,
+)
 
 @pytest.fixture
 def app():
@@ -254,6 +261,15 @@ def test_checkin_wrong_password(client, app):
         refreshed = Inscricao.query.get(insc.id)
         assert refreshed.checkin_attempts == 1
         assert Checkin.query.filter_by(usuario_id=participante.id, oficina_id=oficina.id).count() == 0
+
+
+def test_lista_checkins_requires_privileged_user(client, app):
+    with app.app_context():
+        oficina = Oficina.query.first()
+    login(client, 'part@test', 'p123')
+    resp = client.get(f'/oficina/{oficina.id}/checkins', follow_redirects=True)
+    assert resp.request.path == '/dashboard'
+    assert 'Acesso não autorizado' in resp.get_data(as_text=True)
 
 
 def test_processar_qrcode_success(client, app):


### PR DESCRIPTION
## Summary
- Redirect non-admin users attempting to list check-ins and warn with `Acesso não autorizado`
- Test that participants are redirected when trying to access check-in lists

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c61f87b48332ad7e86bcdfd40af8