### PR TITLE
Fix relatorio routes models import

### DIFF
--- a/routes/relatorio_routes.py
+++ b/routes/relatorio_routes.py
@@ -7,7 +7,7 @@ from flask_login import login_required, current_user
 from io import BytesIO
 from openpyxl import Workbook
 from extensions import db
-
+from models import (
     Evento,
     Oficina,
     Inscricao,


### PR DESCRIPTION
## Summary
- include Evento and related models in a proper `from models` import in `relatorio_routes`

## Testing
- `flake8 routes/relatorio_routes.py` (fails: F401 unused imports, E402, E501 etc.)
- `pytest` (fails: 29 errors during collection)


------
https://chatgpt.com/codex/tasks/task_e_68a4e76cf3648332b111f58b2a08cbe7