### PR TITLE
Fix models import in professor routes

### DIFF
--- a/routes/professor_routes.py
+++ b/routes/professor_routes.py
@@ -10,11 +10,10 @@ from fpdf import FPDF
 from PIL import Image
 
 from extensions import db
-
+from models import (
     Evento, ProfessorBloqueado, SalaVisitacao, HorarioVisitacao,
     AgendamentoVisita, AlunoVisitante, ConfiguracaoAgendamento, Oficina,
     Inscricao,
-
 )
 from services.pdf_service import gerar_pdf_comprovante_agendamento
 from . import routes


### PR DESCRIPTION
## Summary
- fix malformed import block in `routes/professor_routes.py`

## Testing
- `pytest` *(fails: tests contain indentation errors and missing environment variable `SECRET_KEY`)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ec15e6f483328121e4432e51b107