### PR TITLE
Remove unused FPDF and PIL imports from professor routes

### DIFF
--- a/routes/professor_routes.py
+++ b/routes/professor_routes.py
@@ -6,8 +6,6 @@ from datetime import datetime, timedelta
 import os
 import io
 import qrcode
-from fpdf import FPDF
-from PIL import Image
 
 from extensions import db
 


### PR DESCRIPTION
## Summary
- remove unused FPDF and PIL Image imports from professor routes

## Testing
- `flake8 routes/professor_routes.py` *(fails: IndentationError: unexpected indent)*
- `pytest` *(fails: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ec1747748332bc8d821837cf143d