### PR TITLE
Fix revisor model imports

### DIFF
--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -33,25 +33,17 @@ from sqlalchemy import func, desc
 from sqlalchemy.orm import selectinload
 from sqlalchemy.exc import ProgrammingError
 
-
-
+from models import (
     Assignment,
     CampoFormulario,
     Cliente,
-
     ConfiguracaoCliente,
-
-
     Evento,
     Formulario,
-
-
-
     EventoBarema,
     ProcessoBarema,
     ProcessoBaremaRequisito,
     RevisorCandidatura,
-
     RevisorCandidaturaEtapa,
     RevisorEtapa,
     RevisorProcess,


### PR DESCRIPTION
## Summary
- correct broken model import list in `revisor_routes`

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a4efde04c8833286fa305d38ec4a9a