### PR TITLE
Add docstring for route registration helper

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -10,6 +10,14 @@ def bloquear_usuarios_pendentes():
     return
 
 def register_routes(app):
+    """Register all route blueprints with the given Flask app.
+
+    Args:
+        app (Flask): Application instance to attach blueprints to.
+
+    The function mutates ``app`` by registering multiple blueprints.
+    """
+
     # Importações e registros dos Blueprints de módulos organizados
     from .auth_routes import auth_routes
     from .dashboard_routes import dashboard_routes


### PR DESCRIPTION
## Summary
- document register_routes to clarify blueprint registration responsibilities

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a4efe42c948332abe28585fe4b1f90