### PR TITLE
Conditionally register reCAPTCHA debug routes

### DIFF
--- a/app.py
+++ b/app.py
@@ -84,13 +84,24 @@ def create_app():
     from routes import register_routes
     register_routes(app)
     
-    # Registro de rotas de diagnóstico (remova ou comente em produção se necessário)
-    try:
-        from routes.debug_recaptcha_routes import debug_recaptcha_routes
-        app.register_blueprint(debug_recaptcha_routes)
-        app.logger.info("Rotas de diagnóstico de reCAPTCHA registradas - REMOVER EM PRODUÇÃO")
-    except ImportError as e:
-        app.logger.warning(f"Não foi possível carregar rotas de diagnóstico: {e}")
+    # Registro de rotas de diagnóstico (opcional em desenvolvimento)
+    enable_debug_routes = Config.DEBUG or os.getenv("ENABLE_DIAGNOSTIC_ROUTES") == "1"
+
+    if enable_debug_routes:
+        try:
+            from routes.debug_recaptcha_routes import debug_recaptcha_routes
+            app.register_blueprint(debug_recaptcha_routes)
+            app.logger.info(
+                "Rotas de diagnóstico de reCAPTCHA habilitadas"
+            )
+        except ImportError as e:
+            app.logger.warning(
+                "Não foi possível carregar rotas de diagnóstico: %s", e
+            )
+    else:
+        app.logger.info(
+            "Rotas de diagnóstico de reCAPTCHA desabilitadas"
+        )
 
     # Agendamento do reconciliador e rotas utilitárias são registrados aqui
     scheduler = BackgroundScheduler()


### PR DESCRIPTION
## Summary
- Register reCAPTCHA diagnostic routes only when debug flag or `ENABLE_DIAGNOSTIC_ROUTES` is set
- Log whether diagnostic routes were enabled or skipped

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a4efe5eb2883329313dd4089c38b5c