### PR TITLE
Remove unused pending-user middleware

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -3,11 +3,8 @@ from flask import Blueprint
 # Cria o Blueprint principal
 routes = Blueprint("routes", __name__)
 
-# Middleware para permitir acesso a usuários pendentes (ajustável conforme regra de negócio)
-@routes.before_request
-def bloquear_usuarios_pendentes():
-    # Atualmente o acesso é liberado para todos os usuários
-    return
+# Usuários com pagamento pendente continuam com acesso liberado, portanto
+# nenhum middleware de bloqueio é aplicado ao blueprint.
 
 def register_routes(app):
     # Importações e registros dos Blueprints de módulos organizados


### PR DESCRIPTION
## Summary
- remove unused before_request hook that purported to block pending users
- note in blueprint comment that pending users retain access without blocking

## Testing
- `pytest` *(fails: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a4efe83a98833298ece34d3c3df9ca