### PR TITLE
Fix revisor helpers models import

### DIFF
--- a/utils/revisor_helpers.py
+++ b/utils/revisor_helpers.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List
 from flask import Request
 
 from extensions import db
-
+from models import (
     Evento,
     RevisorCriterio,
     RevisorEtapa,


### PR DESCRIPTION
## Summary
- add missing models import block in utils/revisor_helpers

## Testing
- `pytest tests/test_revisor_helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_68a4f4782f948332b1d3c5dc8ef664f4