### PR TITLE
Refactor normalize_pg usage

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ from flask_cors import CORS
 from flask_socketio import join_room
 from apscheduler.schedulers.background import BackgroundScheduler
 from datetime import datetime, timedelta
-from config import Config
+from config import Config, normalize_pg
 from extensions import db, login_manager, migrate, mail, socketio, csrf
 from models import Inscricao
 import pytz
@@ -33,7 +33,7 @@ def create_app():
     app = Flask(__name__)
     app.config.from_object(Config)
     # Normaliza o URI para garantir que seja uma string
-    app.config["SQLALCHEMY_DATABASE_URI"] = Config.normalize_pg(
+    app.config["SQLALCHEMY_DATABASE_URI"] = normalize_pg(
         app.config["SQLALCHEMY_DATABASE_URI"]
     )
     # Recalcula as opções de conexão caso o URI tenha sido alterado nos testes

--- a/config.py
+++ b/config.py
@@ -8,6 +8,7 @@ load_dotenv()
 # ------------------------------------------------------------------ #
 #  Helpers                                                           #
 # ------------------------------------------------------------------ #
+
 def normalize_pg(uri: str | bytes) -> str:
     """Garante o prefixo aceito pelo SQLAlchemy/psycopg2."""
     if isinstance(uri, bytes):
@@ -27,7 +28,7 @@ class Config:
         raise RuntimeError(
             "SECRET_KEY environment variable is required; define a secure value."
         )
-    
+
     # ------------------------------------------------------------------ #
     #  Ambiente de desenvolvimento                                       #
     # ------------------------------------------------------------------ #
@@ -57,10 +58,6 @@ class Config:
         _URI_FROM_ENV
         or f"postgresql://{DB_USER}:{DB_PASS}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
     )
-
-    @staticmethod
-    def normalize_pg(uri: str | bytes) -> str:
-        return normalize_pg(uri)
 
     @staticmethod
     def build_engine_options(uri: str) -> dict:
@@ -97,7 +94,9 @@ class Config:
     # ------------------------------------------------------------------ #
     # Configurações do provedor de e-mail (Mailjet)
     MAILJET_API_KEY = os.getenv("MAILJET_API_KEY") or os.getenv("MAIL_USERNAME", "")
-    MAILJET_SECRET_KEY = os.getenv("MAILJET_SECRET_KEY") or os.getenv("MAIL_PASSWORD", "")
+    MAILJET_SECRET_KEY = (
+        os.getenv("MAILJET_SECRET_KEY") or os.getenv("MAIL_PASSWORD", "")
+    )
 
     MAIL_SERVER = "in-v3.mailjet.com"
     MAIL_PORT = 587


### PR DESCRIPTION
## Summary
- remove unused Config.normalize_pg
- call module-level normalize_pg in app initialization
- format config for flake8

## Testing
- `flake8 --max-line-length=88 config.py`
- `pytest` *(fails: SECRET_KEY environment variable is required; 26 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a513d384708332a850998f0871ee14