### PR TITLE
Require explicit DB_PASS configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,11 @@ RECAPTCHA_PRIVATE_KEY=
 DATABASE_URL=
 DB_ONLINE=
 DB_LOCAL=
+DB_USER=postgres
+DB_PASS=
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=iafap_database
 
 # Mercado Pago API token enabling payment features
 MERCADOPAGO_ACCESS_TOKEN=

--- a/config.py
+++ b/config.py
@@ -42,7 +42,11 @@ class Config:
     #  Parâmetros individuais (podem vir de .env ou variáveis do sistema) #
     # ------------------------------------------------------------------ #
     DB_USER = os.getenv("DB_USER", "postgres")
-    DB_PASS = os.getenv("DB_PASS", "postgres")          # <- senha padrão
+    DB_PASS = os.getenv("DB_PASS")
+    if not DB_PASS:
+        raise RuntimeError(
+            "DB_PASS environment variable is required; set the database password."
+        )
     DB_HOST = os.getenv("DB_HOST", "localhost")
     DB_PORT = os.getenv("DB_PORT", "5432")
     DB_NAME = os.getenv("DB_NAME", "iafap_database")


### PR DESCRIPTION
## Summary
- Require DB_PASS env var with no default and raise RuntimeError when missing
- Document DB connection variables in `.env.example`

## Testing
- `DB_PASS=dummy SECRET_KEY=test /usr/local/bin/pytest tests/config` *(fails: file or directory not found)*
- `DB_PASS=dummy SECRET_KEY=test GOOGLE_CLIENT_ID=foo GOOGLE_CLIENT_SECRET=bar /usr/local/bin/pytest tests/test_config_bytes_database_url.py tests/test_config_event_route.py tests/test_config_cliente_review.py tests/test_sqlite_config.py -q` *(fails: IndentationError in routes/relatorio_pdf_routes.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a513d4b06c8332833b14a319f3bfbc