### PR TITLE
Add docstring for gerar_inscritos_pdf_route

### DIFF
--- a/routes/relatorio_pdf_routes.py
+++ b/routes/relatorio_pdf_routes.py
@@ -10,7 +10,7 @@ from reportlab.lib.styles import getSampleStyleSheet
 from sqlalchemy import func
 from decimal import Decimal
 
-
+from models import (
     db,
     Oficina,
     Feedback,
@@ -43,6 +43,7 @@ relatorio_pdf_routes = Blueprint("relatorio_pdf_routes", __name__)
 @relatorio_pdf_routes.route('/gerar_pdf_inscritos/<int:oficina_id>')
 @login_required
 def gerar_inscritos_pdf_route(oficina_id):
+    """Gera um PDF dos inscritos da oficina especificada pelo oficina_id."""
     return gerar_pdf_inscritos_pdf(oficina_id)
 
 # faça o mesmo para outras rotas PDF...


### PR DESCRIPTION
## Summary
- document gerar_inscritos_pdf_route to clarify PDF generation for a specific oficina

## Testing
- `flake8 routes/relatorio_pdf_routes.py` *(fails: E501 line too long; F401 unused imports)*
- `pytest` *(fails: unexpected indent and missing SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68a513d5a7908332ba056fa45fd6f515