### PR TITLE
Fix missing models import in relatorio_pdf_routes

### DIFF
--- a/routes/relatorio_pdf_routes.py
+++ b/routes/relatorio_pdf_routes.py
@@ -10,7 +10,7 @@ from reportlab.lib.styles import getSampleStyleSheet
 from sqlalchemy import func
 from decimal import Decimal
 
-
+from models import (
     db,
     Oficina,
     Feedback,


### PR DESCRIPTION
## Summary
- add missing `from models import` statement and format import list

## Testing
- `python -m py_compile routes/relatorio_pdf_routes.py`
- `pytest` *(fails: SECRET_KEY environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_e_68a513d6f88c8332baf2f4affc7d6191