### PR TITLE
Define DEBUG flag in Config

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,6 +1,5 @@
 import os
 from dotenv import load_dotenv
-
 from sqlalchemy.pool import QueuePool
 
 # Carrega o arquivo .env explicitamente
@@ -9,6 +8,8 @@ load_dotenv()
 # ------------------------------------------------------------------ #
 #  Helpers                                                           #
 # ------------------------------------------------------------------ #
+
+
 def normalize_pg(uri: str | bytes) -> str:
     """Garante o prefixo aceito pelo SQLAlchemy/psycopg2."""
     if isinstance(uri, bytes):
@@ -19,35 +20,54 @@ def normalize_pg(uri: str | bytes) -> str:
 # ------------------------------------------------------------------ #
 #  Config                                                            #
 # ------------------------------------------------------------------ #
+
+
 class Config:
+    """Application configuration settings."""
+
     # ------------------------------------------------------------------ #
     #  Chave secreta                                                     #
     # ------------------------------------------------------------------ #
-
     SECRET_KEY = os.getenv("SECRET_KEY")
     if not SECRET_KEY:
         raise RuntimeError(
             "SECRET_KEY environment variable is required; define a secure value."
         )
-DB_USER = os.getenv("DB_USER", "postgres")
-DB_PASS = os.getenv("DB_PASS")
 
-if not DB_PASS:
-    if DEBUG:
-        DB_PASS = "postgres"  # fallback só para dev
-    else:
-        raise RuntimeError(
-            "DB_PASS environment variable is required; set the database password."
-        )
+    # ------------------------------------------------------------------ #
+    #  Ambiente de desenvolvimento                                       #
+    # ------------------------------------------------------------------ #
+    DEBUG = os.getenv("FLASK_DEBUG") == "1"
 
-DB_HOST = os.getenv("DB_HOST", "localhost")
-DB_PORT = os.getenv("DB_PORT", "5432")
-DB_NAME = os.getenv("DB_NAME", "iafap_database")
+    # ------------------------------------------------------------------ #
+    #  Logging                                                           #
+    # ------------------------------------------------------------------ #
+    LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+
+    # ------------------------------------------------------------------ #
+    #  Parâmetros individuais (podem vir de .env ou variáveis do sistema) #
+    # ------------------------------------------------------------------ #
+    DB_USER = os.getenv("DB_USER", "postgres")
+    DB_PASS = os.getenv("DB_PASS")
+    if not DB_PASS:
+        if DEBUG:
+            DB_PASS = "postgres"  # fallback só para dev
+        else:
+            raise RuntimeError(
+                "DB_PASS environment variable is required; set the database password."
+            )
+    DB_HOST = os.getenv("DB_HOST", "localhost")
+    DB_PORT = os.getenv("DB_PORT", "5432")
+    DB_NAME = os.getenv("DB_NAME", "iafap_database")
+
+    # Se existir DATABASE_URL / DB_ONLINE, ele tem prioridade
+    _URI_FROM_ENV = os.getenv("DB_ONLINE") or os.getenv("DATABASE_URL")
 
     SQLALCHEMY_DATABASE_URI = normalize_pg(
         _URI_FROM_ENV
         or f"postgresql://{DB_USER}:{DB_PASS}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
     )
+
     @staticmethod
     def normalize_pg(uri: str | bytes) -> str:
         return normalize_pg(uri)


### PR DESCRIPTION
## Summary
- add DEBUG flag to Config sourced from FLASK_DEBUG
- use DEBUG for database password fallback

## Testing
- `pytest` *(fails: DB_PASS or SECRET_KEY env vars missing; 64 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a51b37b97c8332923f7be4a91f5fa9