### PR TITLE
Avoid UndefinedError in revisor config template

### DIFF
--- a/templates/revisor/config.html
+++ b/templates/revisor/config.html
@@ -48,15 +48,16 @@
     <div class="mb-3">
       <label class="form-label">Barema (Critérios e Requisitos)</label>
       {% set crit_total = criterios|length %}
-      {% for c in criterios %}
-      <div class="border rounded p-3 mb-3">
-        <input type="text" class="form-control mb-2" name="criterio_nome" value="{{ c.nome }}">
-        {% for r in c.requisitos %}
-        <input type="text" class="form-control mb-1" name="criterio_{{ loop.parent.index0 }}_requisito" value="{{ r.descricao }}">
+        {% for c in criterios %}
+        {% set outer_index = loop.index0 %}
+        <div class="border rounded p-3 mb-3">
+          <input type="text" class="form-control mb-2" name="criterio_nome" value="{{ c.nome }}">
+          {% for r in c.requisitos %}
+          <input type="text" class="form-control mb-1" name="criterio_{{ outer_index }}_requisito" value="{{ r.descricao }}">
+          {% endfor %}
+          <input type="text" class="form-control mb-1" name="criterio_{{ loop.index0 }}_requisito" placeholder="Novo requisito">
+        </div>
         {% endfor %}
-        <input type="text" class="form-control mb-1" name="criterio_{{ loop.index0 }}_requisito" placeholder="Novo requisito">
-      </div>
-      {% endfor %}
       <div class="border rounded p-3 mb-3">
         <input type="text" class="form-control mb-2" name="criterio_nome" placeholder="Novo critério">
         <input type="text" class="form-control mb-1" name="criterio_{{ crit_total }}_requisito" placeholder="Requisito">


### PR DESCRIPTION
## Summary
- capture outer loop index before inner loops in `revisor/config.html`
- use captured index to reference criteria requisites

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: 15 errors during collection)*
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68a7540f5518833289db6e94fe5f75be