### PR TITLE
Add spreadsheet import flow for works

### DIFF
--- a/templates/trabalho/selecionar_colunas_trabalho.html
+++ b/templates/trabalho/selecionar_colunas_trabalho.html
@@ -1,19 +1,26 @@
 {% extends 'base.html' %}
 {% block content %}
 <div class="container mt-4">
-  <h3>Selecione colunas para importar</h3>
+  <h3>Mapear colunas da planilha</h3>
   <form method="POST">
     {% if csrf_token is defined %}
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     {% endif %}
     <input type="hidden" name="data" value="{{ data_json }}">
-    {% for col in columns %}
-      <div class="form-check">
-        <input class="form-check-input" type="checkbox" name="columns" value="{{ col }}" id="col_{{ loop.index }}">
-        <label class="form-check-label" for="col_{{ loop.index }}">{{ col }}</label>
+    {% for field in fields %}
+      <div class="mb-3">
+        <label class="form-label" for="{{ field }}">
+          {{ field.replace('_', ' ')|title }}
+        </label>
+        <select class="form-select" name="{{ field }}" id="{{ field }}" required>
+          <option value="">Selecione</option>
+          {% for col in columns %}
+            <option value="{{ col }}">{{ col }}</option>
+          {% endfor %}
+        </select>
       </div>
     {% endfor %}
-    <button class="btn btn-success mt-3" type="submit">Importar</button>
+    <button class="btn btn-success" type="submit">Importar</button>
   </form>
 </div>
 {% endblock %}

--- a/tests/test_importar_trabalhos.py
+++ b/tests/test_importar_trabalhos.py
@@ -1,14 +1,24 @@
 import io
 import json
 import os
+
 import pandas as pd
 import pytest
+
 from extensions import db
 from models import WorkMetadata
 
 
 def make_excel():
-    df = pd.DataFrame({"titulo": ["T1"], "resumo": ["R1"], "extra": ["E1"]})
+    df = pd.DataFrame(
+        {
+            "t": ["T1"],
+            "cat": ["C1"],
+            "rede": ["R1"],
+            "et": ["E1"],
+            "pdf": ["L1"],
+        }
+    )
     buffer = io.BytesIO()
     with pd.ExcelWriter(buffer, engine="xlsxwriter") as writer:
         df.to_excel(writer, index=False)
@@ -22,6 +32,7 @@ def app():
     os.environ.setdefault("GOOGLE_CLIENT_ID", "x")
     os.environ.setdefault("GOOGLE_CLIENT_SECRET", "x")
     os.environ.setdefault("DB_ONLINE", "sqlite:///:memory:")
+    os.environ.setdefault("DB_PASS", "test")
     from app import create_app
 
     app = create_app()
@@ -47,17 +58,30 @@ def test_upload_and_persist(client, app):
         content_type="multipart/form-data",
     )
     assert resp.status_code == 200
-    assert b"titulo" in resp.data
-    assert b"resumo" in resp.data
+    assert b"name=\"titulo\"" in resp.data
+    assert b"<option value=\"t\"" in resp.data
 
     data_json = df.to_dict(orient="records")
     resp = client.post(
         "/importar_trabalhos",
-        data={"columns": ["titulo", "resumo"], "data": json.dumps(data_json)},
+        data={
+            "titulo": "t",
+            "categoria": "cat",
+            "rede_ensino": "rede",
+            "etapa": "et",
+            "link_pdf": "pdf",
+            "data": json.dumps(data_json),
+        },
         follow_redirects=True,
     )
     assert resp.status_code == 200
     with app.app_context():
         rows = WorkMetadata.query.all()
         assert len(rows) == 1
-        assert rows[0].data == {"titulo": "T1", "resumo": "R1"}
+        assert rows[0].data == {
+            "titulo": "T1",
+            "categoria": "C1",
+            "rede_ensino": "R1",
+            "etapa": "E1",
+            "link_pdf": "L1",
+        }


### PR DESCRIPTION
## Summary
- add `/importar_trabalhos` route with two-step spreadsheet upload and mapping into `WorkMetadata`
- update column selection template to map columns to required metadata fields
- cover import flow with tests

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: unexpected indent and missing module in unrelated tests)*
- `pytest tests/test_importar_trabalhos.py`

------
https://chatgpt.com/codex/tasks/task_e_68a7578247548332a0e198522dd0c866