### PR TITLE
Add distribution upload flow with mapping interface

### DIFF
--- a/templates/trabalho/distribuicao.html
+++ b/templates/trabalho/distribuicao.html
@@ -1,0 +1,57 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container mt-4">
+  <h3>Distribuição de Trabalhos</h3>
+
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+      {% for category, message in messages %}
+        <div class="alert alert-{{ category }}">{{ message }}</div>
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
+
+  {% if columns %}
+    <form method="post">
+      <input type="hidden" name="data" value='{{ data_json }}'>
+      {% for campo in campos %}
+        <div class="mb-3">
+          <label for="map_{{ campo }}" class="form-label">{{ campo|capitalize }}</label>
+          <select class="form-select" name="map_{{ campo }}" id="map_{{ campo }}">
+            {% for col in columns %}
+              <option value="{{ col }}">{{ col }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      {% endfor %}
+      <h4>Pré-visualização</h4>
+      <table class="table table-bordered">
+        <thead>
+          <tr>
+            {% for col in columns %}
+              <th>{{ col }}</th>
+            {% endfor %}
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in data_preview %}
+            <tr>
+              {% for col in columns %}
+                <td>{{ row[col] }}</td>
+              {% endfor %}
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      <button class="btn btn-success" type="submit">Confirmar</button>
+    </form>
+  {% else %}
+    <form method="post" enctype="multipart/form-data">
+      <div class="mb-3">
+        <input class="form-control" type="file" name="arquivo" accept=".xls,.xlsx" required>
+      </div>
+      <button class="btn btn-primary" type="submit">Enviar</button>
+    </form>
+  {% endif %}
+</div>
+{% endblock %}

--- a/tests/test_trabalho_distribuicao.py
+++ b/tests/test_trabalho_distribuicao.py
@@ -1,0 +1,72 @@
+import io
+import json
+import os
+
+import pandas as pd
+import pytest
+
+from extensions import db
+from models import WorkMetadata
+
+
+def make_excel():
+    df = pd.DataFrame({"titulo": ["T1"], "resumo": ["R1"], "extra": ["E1"]})
+    buffer = io.BytesIO()
+    with pd.ExcelWriter(buffer, engine="xlsxwriter") as writer:
+        df.to_excel(writer, index=False)
+    buffer.seek(0)
+    return buffer, df
+
+
+@pytest.fixture
+def app():
+    os.environ.setdefault("SECRET_KEY", "test")
+    os.environ.setdefault("GOOGLE_CLIENT_ID", "x")
+    os.environ.setdefault("GOOGLE_CLIENT_SECRET", "x")
+    os.environ.setdefault("DB_ONLINE", "sqlite:///:memory:")
+    os.environ.setdefault("DB_PASS", "test")
+    from app import create_app
+
+    app = create_app()
+    app.config["TESTING"] = True
+    app.config["WTF_CSRF_ENABLED"] = False
+    app.config["LOGIN_DISABLED"] = True
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    with app.app_context():
+        db.create_all()
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def test_distribuicao_flow(client, app):
+    excel, df = make_excel()
+    resp = client.post(
+        "/distribuicao",
+        data={"arquivo": (excel, "dados.xlsx")},
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 200
+    assert b"titulo" in resp.data
+    assert b"resumo" in resp.data
+
+    data_json = df.to_dict(orient="records")
+    resp = client.post(
+        "/distribuicao",
+        data={
+            "data": json.dumps(data_json),
+            "map_titulo": "titulo",
+            "map_resumo": "resumo",
+        },
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    assert b"Dados importados com sucesso" in resp.data
+    with app.app_context():
+        rows = WorkMetadata.query.all()
+        assert len(rows) == 1
+        assert rows[0].data == {"titulo": "T1", "resumo": "R1"}
+


### PR DESCRIPTION
## Summary
- add new route for spreadsheet distribution with column mapping and preview
- provide integrated distribution template and success/error flashes
- cover distribution workflow with functional test

## Testing
- `python -m pip install -r requirements-dev.txt`
- `pytest` *(fails: 15 errors during collection)*
- `pytest tests/test_trabalho_distribuicao.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a757903afc8332a267965c87fe543d