### PR TITLE
Add Excel import for submission distribution

### DIFF
--- a/routes/config_cliente_routes.py
+++ b/routes/config_cliente_routes.py
@@ -24,6 +24,10 @@ from models import (
 
 from datetime import datetime
 import logging
+import uuid
+import secrets
+import pandas as pd
+from werkzeug.security import generate_password_hash
 
 config_cliente_routes = Blueprint("config_cliente_routes", __name__)
 
@@ -936,6 +940,36 @@ def toggle_configuracao_evento(evento_id, campo):
     setattr(config, campo, not getattr(config, campo))
     db.session.commit()
     return jsonify({"success": True, "value": getattr(config, campo)})
+
+
+@config_cliente_routes.route("/importar_trabalhos", methods=["POST"])
+@login_required
+def importar_trabalhos():
+    """Importa trabalhos a partir de planilha Excel."""
+    if current_user.tipo != "cliente":
+        return jsonify({"success": False, "message": "Acesso negado"}), 403
+    file = request.files.get("arquivo")
+    if not file:
+        return jsonify({"success": False, "message": "Arquivo não enviado"}), 400
+    try:
+        df = pd.read_excel(file)
+    except Exception:
+        return jsonify({"success": False, "message": "Erro ao ler arquivo"}), 400
+
+    for _, row in df.iterrows():
+        title = row.get("title") or row.get("titulo")
+        if not title:
+            continue
+        locator = str(uuid.uuid4())
+        raw_code = secrets.token_urlsafe(8)[:8]
+        submission = Submission(
+            title=title,
+            locator=locator,
+            code_hash=generate_password_hash(raw_code),
+        )
+        db.session.add(submission)
+    db.session.commit()
+    return jsonify({"success": True})
 
 
 @config_cliente_routes.route("/config_submissao")

--- a/static/js/config_submissao.js
+++ b/static/js/config_submissao.js
@@ -39,4 +39,25 @@
       }
     });
   });
+
+  const form = document.getElementById('formImportarTrabalhos');
+  attachOnce(form, 'submit', async (ev) => {
+    ev.preventDefault();
+    const formData = new FormData(form);
+    try {
+      const resp = await fetch(form.action, {
+        method: 'POST',
+        body: formData,
+        headers: { 'X-CSRFToken': csrfToken },
+      });
+      if (resp.ok) {
+        window.location.reload();
+      } else {
+        const data = await resp.json().catch(() => null);
+        alert(data?.message || 'Erro ao importar');
+      }
+    } catch (err) {
+      console.error('Erro de rede', err);
+    }
+  });
 })();

--- a/templates/config/config_submissao.html
+++ b/templates/config/config_submissao.html
@@ -153,6 +153,16 @@
       </h2>
       <div id="collapseDistribuicao" class="accordion-collapse collapse" aria-labelledby="headingDistribuicao" data-bs-parent="#accordionDistribuicao">
         <div class="accordion-body">
+          <form id="formImportarTrabalhos"
+                class="mb-3"
+                method="post"
+                enctype="multipart/form-data"
+                action="{{ url_for('config_cliente_routes.importar_trabalhos') }}">
+            <div class="input-group">
+              <input class="form-control" type="file" name="arquivo" accept=".xls,.xlsx">
+              <button class="btn btn-primary" type="submit">Importar</button>
+            </div>
+          </form>
           <table class="table table-striped">
             <thead>
               <tr>

--- a/tests/test_config_cliente_review.py
+++ b/tests/test_config_cliente_review.py
@@ -1,5 +1,7 @@
 import pytest
 import os
+import io
+import pandas as pd
 os.environ.setdefault('SECRET_KEY', 'test')
 os.environ.setdefault('GOOGLE_CLIENT_ID', 'x')
 os.environ.setdefault('GOOGLE_CLIENT_SECRET', 'y')
@@ -126,3 +128,21 @@ def test_revisao_config_update_and_interface(client, app):
     assert b'id="selectModeloBlind"' in resp.data
     assert b'"numero_revisores": 3' in resp.data
     assert b'"modelo_blind": "double"' in resp.data
+
+
+def test_importar_trabalhos_aparece_na_tabela(client, app):
+    login(client, 'cli@example.com', '123')
+    df = pd.DataFrame({'title': ['Trabalho X']})
+    buffer = io.BytesIO()
+    with pd.ExcelWriter(buffer, engine='xlsxwriter') as writer:
+        df.to_excel(writer, index=False)
+    buffer.seek(0)
+    resp = client.post(
+        '/importar_trabalhos',
+        data={'arquivo': (buffer, 'dados.xlsx')},
+        content_type='multipart/form-data',
+    )
+    assert resp.status_code == 200
+    resp = client.get('/config_submissao')
+    assert resp.status_code == 200
+    assert b'Trabalho X' in resp.data


### PR DESCRIPTION
## Summary
- add file upload form for Distribuição de Trabalhos
- implement route to import submissions from Excel
- send upload via AJAX and update page
- test importing submissions through new endpoint

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError in tests/test_assign_by_filters.py and others)*
- `DB_PASS=test pytest tests/test_config_cliente_review.py::test_importar_trabalhos_aparece_na_tabela -q`


------
https://chatgpt.com/codex/tasks/task_e_68a75e5816708332a01117716272a915