### PR TITLE
Enable column mapping modal for work imports

### DIFF
--- a/routes/config_cliente_routes.py
+++ b/routes/config_cliente_routes.py
@@ -942,34 +942,6 @@ def toggle_configuracao_evento(evento_id, campo):
     return jsonify({"success": True, "value": getattr(config, campo)})
 
 
-@config_cliente_routes.route("/importar_trabalhos", methods=["POST"])
-@login_required
-def importar_trabalhos():
-    """Importa trabalhos a partir de planilha Excel."""
-    if current_user.tipo != "cliente":
-        return jsonify({"success": False, "message": "Acesso negado"}), 403
-    file = request.files.get("arquivo")
-    if not file:
-        return jsonify({"success": False, "message": "Arquivo não enviado"}), 400
-    try:
-        df = pd.read_excel(file)
-    except Exception:
-        return jsonify({"success": False, "message": "Erro ao ler arquivo"}), 400
-
-    for _, row in df.iterrows():
-        title = row.get("title") or row.get("titulo")
-        if not title:
-            continue
-        locator = str(uuid.uuid4())
-        raw_code = secrets.token_urlsafe(8)[:8]
-        submission = Submission(
-            title=title,
-            locator=locator,
-            code_hash=generate_password_hash(raw_code),
-        )
-        db.session.add(submission)
-    db.session.commit()
-    return jsonify({"success": True})
 
 
 @config_cliente_routes.route("/config_submissao")

--- a/routes/importar_trabalhos_routes.py
+++ b/routes/importar_trabalhos_routes.py
@@ -22,7 +22,10 @@ def importar_trabalhos():
     if "arquivo" in request.files:
         file = request.files["arquivo"]
         df = pd.read_excel(file)
-        return jsonify({"columns": df.columns.tolist()})
+        return jsonify({
+            "columns": df.columns.tolist(),
+            "data": df.to_dict(orient="records"),
+        })
 
     columns = request.form.getlist("columns")
     data_json = request.form.get("data")
@@ -45,4 +48,4 @@ def importar_trabalhos():
         )
         db.session.add(wm)
     db.session.commit()
-    return jsonify({"status": "ok"})
+    return jsonify({"status": "ok", "message": "Importação concluída"})

--- a/static/js/config_submissao.js
+++ b/static/js/config_submissao.js
@@ -41,6 +41,9 @@
   });
 
   const form = document.getElementById('formImportarTrabalhos');
+  const modalContainer = document.getElementById('mapearColunasModal');
+  const template = document.getElementById('mapearColunasTemplate');
+
   attachOnce(form, 'submit', async (ev) => {
     ev.preventDefault();
     const formData = new FormData(form);
@@ -50,11 +53,84 @@
         body: formData,
         headers: { 'X-CSRFToken': csrfToken },
       });
-      if (resp.ok) {
-        window.location.reload();
-      } else {
-        const data = await resp.json().catch(() => null);
-        alert(data?.message || 'Erro ao importar');
+      if (!resp.ok) {
+        const errData = await resp.json().catch(() => null);
+        alert(errData?.message || 'Erro ao importar');
+        return;
+      }
+      const data = await resp.json();
+      const columns = data.columns || [];
+      const rows = data.data || [];
+      if (!columns.length) {
+        alert('Nenhuma coluna encontrada');
+        return;
+      }
+
+      if (template && modalContainer) {
+        modalContainer.innerHTML = template.innerHTML;
+        const modalEl = modalContainer.querySelector('.modal');
+        const selectsWrap = modalEl.querySelector('#mapearCampos');
+        const fields = ['titulo', 'categoria', 'rede_ensino', 'etapa_ensino', 'pdf_url'];
+        fields.forEach((field) => {
+          const div = document.createElement('div');
+          div.className = 'mb-3';
+          const label = document.createElement('label');
+          label.className = 'form-label';
+          label.htmlFor = field;
+          label.textContent = field.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+          const select = document.createElement('select');
+          select.className = 'form-select';
+          select.id = field;
+          select.dataset.field = field;
+          select.required = true;
+          const optEmpty = document.createElement('option');
+          optEmpty.value = '';
+          optEmpty.textContent = 'Selecione';
+          select.appendChild(optEmpty);
+          columns.forEach((col) => {
+            const opt = document.createElement('option');
+            opt.value = col;
+            opt.textContent = col;
+            select.appendChild(opt);
+          });
+          div.appendChild(label);
+          div.appendChild(select);
+          selectsWrap.appendChild(div);
+        });
+
+        const modal = new bootstrap.Modal(modalEl);
+        const confirmBtn = modalEl.querySelector('#confirmarMapeamento');
+        attachOnce(confirmBtn, 'click', async () => {
+          const selects = selectsWrap.querySelectorAll('select');
+          const chosen = [];
+          for (const sel of selects) {
+            if (!sel.value) {
+              alert('Preencha todas as colunas');
+              return;
+            }
+            chosen.push(sel.value);
+          }
+          const payload = new FormData();
+          chosen.forEach((c) => payload.append('columns', c));
+          payload.append('data', JSON.stringify(rows));
+          try {
+            const resp2 = await fetch(form.action, {
+              method: 'POST',
+              body: payload,
+              headers: { 'X-CSRFToken': csrfToken },
+            });
+            const resData = await resp2.json().catch(() => null);
+            if (resp2.ok) {
+              alert(resData?.message || 'Importação concluída');
+              window.location.reload();
+            } else {
+              alert(resData?.message || 'Erro ao importar');
+            }
+          } catch (err2) {
+            console.error('Erro de rede', err2);
+          }
+        });
+        modal.show();
       }
     } catch (err) {
       console.error('Erro de rede', err);

--- a/templates/config/config_submissao.html
+++ b/templates/config/config_submissao.html
@@ -157,7 +157,7 @@
                 class="mb-3"
                 method="post"
                 enctype="multipart/form-data"
-                action="{{ url_for('config_cliente_routes.importar_trabalhos') }}">
+                action="{{ url_for('importar_trabalhos_routes.importar_trabalhos') }}">
             <div class="input-group">
               <input class="form-control" type="file" name="arquivo" accept=".xls,.xlsx">
               <button class="btn btn-primary" type="submit">Importar</button>
@@ -227,6 +227,10 @@
       </div>
     </div>
   </div>
+  <div id="mapearColunasModal"></div>
+  <script type="text/template" id="mapearColunasTemplate">
+    {% include 'trabalho/selecionar_colunas_trabalho.html' %}
+  </script>
 
   </div>
 {% endblock %}

--- a/templates/trabalho/selecionar_colunas_trabalho.html
+++ b/templates/trabalho/selecionar_colunas_trabalho.html
@@ -1,26 +1,20 @@
-{% extends 'base.html' %}
-{% block content %}
-<div class="container mt-4">
-  <h3>Mapear colunas da planilha</h3>
-  <form method="POST">
-    {% if csrf_token is defined %}
-      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-    {% endif %}
-    <input type="hidden" name="data" value="{{ data_json }}">
-    {% for field in fields %}
-      <div class="mb-3">
-        <label class="form-label" for="{{ field }}">
-          {{ field.replace('_', ' ')|title }}
-        </label>
-        <select class="form-select" name="{{ field }}" id="{{ field }}" required>
-          <option value="">Selecione</option>
-          {% for col in columns %}
-            <option value="{{ col }}">{{ col }}</option>
-          {% endfor %}
-        </select>
-      </div>
-    {% endfor %}
-    <button class="btn btn-success" type="submit">Importar</button>
-  </form>
+<div class="modal fade" id="mapearColunasModalInner" tabindex="-1" aria-labelledby="mapearColunasLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="mapearColunasLabel">Mapear colunas da planilha</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+            </div>
+            <div class="modal-body">
+                <form id="formMapearColunas">
+                    <div id="mapearCampos"></div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                <button type="button" class="btn btn-success" id="confirmarMapeamento">Importar</button>
+            </div>
+        </div>
+    </div>
 </div>
-{% endblock %}
+


### PR DESCRIPTION
## Summary
- Switch submission import form to dedicated importer route
- Add reusable modal template for mapping spreadsheet columns
- Update JavaScript to handle two-phase import with column mapping

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: 15 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a762345c44833292c540885b590634