### PR TITLE
Remove distribution accordion from submission config page

### DIFF
--- a/routes/config_cliente_routes.py
+++ b/routes/config_cliente_routes.py
@@ -18,8 +18,6 @@ from models import (
     Evento,
     ConfiguracaoEvento,
     Formulario,
-    Submission,
-    Usuario,
 )
 
 from datetime import datetime
@@ -977,15 +975,10 @@ def config_submissao():
         ).all()
     }
 
-    submissions = Submission.query.all()
-    reviewers = Usuario.query.filter_by(tipo="professor").all()
-
     return render_template(
         "config/config_submissao.html",
         config_cliente=config_cliente,
         eventos=eventos,
         formularios=formularios,
         revisao_configs=revisao_configs,
-        submissions=submissions,
-        reviewers=reviewers,
     )

--- a/templates/config/config_submissao.html
+++ b/templates/config/config_submissao.html
@@ -144,95 +144,10 @@
       </div>
     </div>
     </div>
-  <div class="accordion mt-4" id="accordionDistribuicao">
-    <div class="accordion-item">
-      <h2 class="accordion-header" id="headingDistribuicao">
-        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseDistribuicao" aria-expanded="false" aria-controls="collapseDistribuicao">
-          Distribuição de Trabalhos
-        </button>
-      </h2>
-      <div id="collapseDistribuicao" class="accordion-collapse collapse" aria-labelledby="headingDistribuicao" data-bs-parent="#accordionDistribuicao">
-        <div class="accordion-body">
-          <form id="formImportarTrabalhos"
-                class="mb-3"
-                method="post"
-                enctype="multipart/form-data"
-                action="{{ url_for('importar_trabalhos_routes.importar_trabalhos') }}">
-            <div class="input-group">
-              <input class="form-control" type="file" name="arquivo" accept=".xls,.xlsx">
-              <button class="btn btn-primary" type="submit">Importar</button>
-            </div>
-          </form>
-          <table class="table table-striped">
-            <thead>
-              <tr>
-                <th>Título</th>
-                <th>Localizador</th>
-                <th>Autor</th>
-                <th>Revisores</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for sub in submissions %}
-              <tr>
-                <td>{{ sub.title }}</td>
-                <td>{{ sub.locator }}</td>
-                <td>{{ sub.author.nome if sub.author else 'N/A' }}</td>
-                <td>
-                  <ul class="mb-0">
-                    {% for rev in sub.reviews %}
-                    <li>{{ rev.reviewer.nome if rev.reviewer else 'N/A' }} - {{ rev.access_code }}</li>
-                    {% else %}
-                    <li>Nenhum revisor atribuído</li>
-                    {% endfor %}
-                  </ul>
-                  <button class="btn btn-sm btn-secondary mt-1 gerar-codigos" data-locator="{{ sub.locator }}">Gerar Códigos</button>
-                </td>
-              </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-
-          <div class="mt-5">
-            <h4>Atribuir Revisores</h4>
-            <div class="mb-3">
-              <label for="submissionSelect" class="form-label">Submissão</label>
-              <select id="submissionSelect" class="form-select">
-                {% for sub in submissions %}
-                <option value="{{ sub.id }}">{{ sub.title }}</option>
-                {% endfor %}
-              </select>
-            </div>
-            <div class="mb-3">
-              <label for="reviewerSelect" class="form-label">Revisores</label>
-              <select id="reviewerSelect" class="form-select" multiple
-                      data-min="{{ config_cliente.num_revisores_min if config_cliente else 1 }}"
-                      data-max="{{ config_cliente.num_revisores_max if config_cliente else 2 }}">
-                {% for r in reviewers %}
-                <option value="{{ r.id }}">{{ r.nome }}</option>
-                {% endfor %}
-              </select>
-              <small class="form-text text-muted">
-                Selecione entre {{ config_cliente.num_revisores_min if config_cliente else 1 }} e {{ config_cliente.num_revisores_max if config_cliente else 2 }} revisores.
-              </small>
-            </div>
-            <button id="assignManual" class="btn btn-primary me-2">Atribuir Manualmente</button>
-            <button id="assignAutomatic" class="btn btn-secondary me-2">Sorteio Automático</button>
-            <div class="input-group mt-2" style="max-width: 300px;">
-              <input type="number" id="eventoId" class="form-control" placeholder="ID do Evento" />
-              <button id="autoArea" class="btn btn-info">Auto por Área</button>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div id="mapearColunasModal"></div>
-  <script type="text/template" id="mapearColunasTemplate">
-    {% include 'trabalho/selecionar_colunas_trabalho.html' %}
-  </script>
-
-  </div>
+<div id="mapearColunasModal"></div>
+<script type="text/template" id="mapearColunasTemplate">
+  {% include 'trabalho/selecionar_colunas_trabalho.html' %}
+</script>
 {% endblock %}
 
 

--- a/tests/test_config_cliente_review.py
+++ b/tests/test_config_cliente_review.py
@@ -130,7 +130,7 @@ def test_revisao_config_update_and_interface(client, app):
     assert b'"modelo_blind": "double"' in resp.data
 
 
-def test_importar_trabalhos_aparece_na_tabela(client, app):
+def test_importar_trabalhos_nao_mostra_tabela(client, app):
     login(client, 'cli@example.com', '123')
     df = pd.DataFrame({'title': ['Trabalho X']})
     buffer = io.BytesIO()
@@ -145,4 +145,4 @@ def test_importar_trabalhos_aparece_na_tabela(client, app):
     assert resp.status_code == 200
     resp = client.get('/config_submissao')
     assert resp.status_code == 200
-    assert b'Trabalho X' in resp.data
+    assert b'accordionDistribuicao' not in resp.data


### PR DESCRIPTION
## Summary
- remove submission distribution accordion from client config page
- drop redundant submission/reviewer queries in `config_submissao` route
- adjust tests to reflect accordion removal

## Testing
- `DB_PASS=foo pytest tests/test_config_cliente_review.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a764900e648332a0d226d1f0a4b0d8