### PR TITLE
Handle JSON response in submission import

### DIFF
--- a/static/js/submission_import.js
+++ b/static/js/submission_import.js
@@ -14,14 +14,20 @@
         body: data,
         headers: { 'X-CSRFToken': csrfToken },
       });
+      const resData = await resp.json().catch(() => null);
       if (resp.ok) {
-        window.location.reload();
+        if (resData?.status === 'ok') {
+          alert(resData.message || 'Importação concluída');
+          window.location.reload();
+        } else {
+          alert(resData?.message || 'Erro ao importar');
+        }
       } else {
-        const err = await resp.json().catch(() => null);
-        alert(err?.message || 'Erro ao importar');
+        alert(resData?.message || 'Erro ao importar');
       }
     } catch (error) {
       console.error('Erro de rede', error);
+      alert('Erro de rede');
     }
   });
 })();


### PR DESCRIPTION
## Summary
- Handle JSON responses from `/importar_trabalhos`
- Show feedback messages for success or failure and reload only after completion

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError in tests and missing module `bs4`)*

------
https://chatgpt.com/codex/tasks/task_e_68a76fc7e39883328c0a8a2602aecf82