### PR TITLE
Capture evento_id during submission import

### DIFF
--- a/routes/importar_trabalhos_routes.py
+++ b/routes/importar_trabalhos_routes.py
@@ -21,6 +21,7 @@ def importar_trabalhos():
     1. Upload an Excel file via ``arquivo`` to preview available columns.
     2. Submit selected ``columns`` and ``data`` (JSON list) to persist them.
     """
+    evento_id = request.form.get("evento_id", type=int)
     if "arquivo" in request.files:
         file = request.files["arquivo"]
         df = pd.read_excel(file)
@@ -32,6 +33,7 @@ def importar_trabalhos():
             submission = Submission(
                 title=title,
                 code_hash=generate_password_hash(uuid.uuid4().hex),
+                evento_id=evento_id,
             )
             db.session.add(submission)
         if not df.empty:
@@ -44,7 +46,6 @@ def importar_trabalhos():
 
     columns = request.form.getlist("columns")
     data_json = request.form.get("data")
-    evento_id = request.form.get("evento_id", type=int)
 
     if not data_json:
         return jsonify({"error": "missing data"}), 400

--- a/static/js/submission_import.js
+++ b/static/js/submission_import.js
@@ -3,11 +3,17 @@
   const form = document.getElementById('formImportarTrabalhos');
   if (!form) return;
 
-  const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '';
+  const csrfToken = document
+    .querySelector('meta[name="csrf-token"]')
+    ?.getAttribute('content') || '';
+  const eventoInput = document.getElementById('eventoId');
 
   form.addEventListener('submit', async (ev) => {
     ev.preventDefault();
     const data = new FormData(form);
+    if (eventoInput && eventoInput.value) {
+      data.append('evento_id', eventoInput.value);
+    }
     try {
       const resp = await fetch(form.action, {
         method: 'POST',


### PR DESCRIPTION
## Summary
- attach evento_id to Submissions when importing spreadsheets
- include evento_id in the upload FormData
- test import process persists evento_id

## Testing
- `pytest` (fails: 15 errors during collection)
- `pytest tests/test_importar_trabalhos.py`

------
https://chatgpt.com/codex/tasks/task_e_68a76fcaa3508332bed1a023c1dd1f67