### PR TITLE
Store spreadsheet rows in submission attributes

### DIFF
--- a/routes/importar_trabalhos_routes.py
+++ b/routes/importar_trabalhos_routes.py
@@ -34,13 +34,15 @@ def importar_trabalhos():
 
         imported = 0
         for _, row in df.iterrows():
-            title = row.get("title") or row.get("titulo")
+            row_dict = row.to_dict()
+            title = row_dict.get("title") or row_dict.get("titulo")
             if not title:
                 continue
             submission = Submission(
                 title=title,
                 code_hash=generate_password_hash(uuid.uuid4().hex),
                 evento_id=evento_id,
+                attributes=row_dict,
             )
             db.session.add(submission)
             imported += 1
@@ -63,6 +65,9 @@ def importar_trabalhos():
         return jsonify({"error": "missing data"}), 400
 
     rows = json.loads(data_json)
+    if not columns and rows:
+        columns = list(rows[0].keys())
+
     for row in rows:
         selected = {col: row.get(col) for col in columns}
         wm = WorkMetadata(

--- a/tests/test_importar_trabalhos.py
+++ b/tests/test_importar_trabalhos.py
@@ -61,25 +61,16 @@ def test_upload_and_persist(client, app):
     assert resp.status_code == 200
     assert b"titulo" in resp.data
     assert b"categoria" in resp.data
+    data_json = df.to_dict(orient="records")
     with app.app_context():
         subs = Submission.query.all()
         assert len(subs) == 1
         assert subs[0].evento_id == evento_id
+        assert subs[0].attributes == data_json[0]
 
-    data_json = df.to_dict(orient="records")
     resp = client.post(
         "/importar_trabalhos",
-        data={
-            "columns": [
-                "titulo",
-                "categoria",
-                "rede_ensino",
-                "etapa_ensino",
-                "pdf_url",
-            ],
-            "data": json.dumps(data_json),
-            "evento_id": evento_id,
-        },
+        data={"data": json.dumps(data_json), "evento_id": evento_id},
         follow_redirects=True,
     )
     assert resp.status_code == 200
@@ -93,10 +84,4 @@ def test_upload_and_persist(client, app):
         assert row.rede_ensino == "Rede1"
         assert row.etapa_ensino == "Etapa1"
         assert row.pdf_url == "http://example.com/doc.pdf"
-        assert row.data == {
-            "titulo": "T1",
-            "categoria": "C1",
-            "rede_ensino": "Rede1",
-            "etapa_ensino": "Etapa1",
-            "pdf_url": "http://example.com/doc.pdf",
-        }
+        assert row.data == data_json[0]


### PR DESCRIPTION
## Summary
- Save all spreadsheet data in `Submission.attributes`
- Default metadata import to use all columns when none specified
- Test that submissions and metadata keep every column

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: Interrupted: 15 errors during collection)*
- `pytest tests/test_importar_trabalhos.py`


------
https://chatgpt.com/codex/tasks/task_e_68a776f0d9dc8332a7fef17de5833519