### PR TITLE
Expand code hash field size for submissions

### DIFF
--- a/migrations/versions/36a58e54b28a_increase_submission_code_hash_length.py
+++ b/migrations/versions/36a58e54b28a_increase_submission_code_hash_length.py
@@ -1,0 +1,34 @@
+"""increase submission code_hash length
+
+Revision ID: 36a58e54b28a
+Revises: 79c3c0f95577
+Create Date: 2025-08-21 23:51:10.209505
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '36a58e54b28a'
+down_revision = '79c3c0f95577'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        'submission',
+        'code_hash',
+        existing_type=sa.String(length=128),
+        type_=sa.String(length=256),
+    )
+
+
+def downgrade():
+    op.alter_column(
+        'submission',
+        'code_hash',
+        existing_type=sa.String(length=256),
+        type_=sa.String(length=128),
+    )

--- a/models/review.py
+++ b/models/review.py
@@ -238,7 +238,7 @@ class Submission(db.Model):
 
     # locator & code (para acesso do autor e revisores externos)
     locator = db.Column(db.String(36), unique=True, default=lambda: str(uuid.uuid4()))
-    code_hash = db.Column(db.String(128), nullable=False)
+    code_hash = db.Column(db.String(256), nullable=False)
 
     # metadata
     status = db.Column(db.String(50), nullable=True)


### PR DESCRIPTION
## Summary
- enlarge `Submission.code_hash` to 256 characters
- add migration altering `submission.code_hash` column size

## Testing
- `flask db upgrade` *(fails: sqlite3.OperationalError: near "ALTER")*
- `pytest` *(fails: IndentationError: unexpected indent in tests and ModuleNotFoundError: No module named 'bs4')*


------
https://chatgpt.com/codex/tasks/task_e_68a7b08463508332b2b8085e2f48ce82