### PR TITLE
Specify pbkdf2 for password hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ A variável `DATABASE_URL`, quando definida, deve conter a URI completa do
 banco de dados e tem precedência sobre as variáveis `DB_USER`, `DB_PASS`,
 `DB_HOST`, `DB_PORT` e `DB_NAME`.
 
+## Hash de senhas
+
+As senhas são geradas com `generate_password_hash` utilizando o algoritmo
+`pbkdf2:sha256` e 1.000.000 iterações. O valor final tem 103 caracteres e segue
+o formato `<algoritmo>:<iterações>$<salt>$<hash>`.
+
 ## Banco de Dados
 
 Depois de clonar o repositório ou atualizar o código, instale as dependências

--- a/create_admin.py
+++ b/create_admin.py
@@ -17,7 +17,7 @@ with app.app_context():  # ✅ Criando um contexto da aplicação Flask
             nome="Administrador",
             cpf="00000000001",
             email="admin@email.com",
-            senha=generate_password_hash("admin123"),
+            senha=generate_password_hash("admin123", method="pbkdf2:sha256"),
             formacao="Administrador",
             tipo="admin"
         )

--- a/migrations/versions/f0c6022a4f5a_migrate_trabalhos_to_submission.py
+++ b/migrations/versions/f0c6022a4f5a_migrate_trabalhos_to_submission.py
@@ -59,7 +59,7 @@ def upgrade():
                 "status": row.status,
                 "author_id": row.usuario_id,
                 "evento_id": row.evento_id,
-                "code_hash": generate_password_hash(code),
+                "code_hash": generate_password_hash(code, method="pbkdf2:sha256"),
                 "attributes": attrs,
             },
         )

--- a/populate_script.py
+++ b/populate_script.py
@@ -141,7 +141,7 @@ def criar_clientes(quantidade=5):
             cliente = Cliente(
                 nome=fake.company(),
                 email=email,
-                senha=generate_password_hash(fake.password()),
+                senha=generate_password_hash(fake.password(), method="pbkdf2:sha256"),
                 ativo=True,
                 habilita_pagamento=random.choice([True, False])
             )
@@ -456,7 +456,7 @@ def criar_ministrantes(clientes, quantidade=20):
             cidade=fake.city(),
             estado=random.choice(ESTADOS_BRASIL),
             email=gerar_email_unico(fake),
-            senha=generate_password_hash(fake.password()),
+            senha=generate_password_hash(fake.password(), method="pbkdf2:sha256"),
             cliente_id=cliente.id,
         )
 
@@ -632,7 +632,7 @@ def criar_usuarios(clientes, quantidade=150):
                 nome="Administrador do Sistema",
                 cpf=fake.unique.cpf(),
                 email="admin@sistema.com",
-                senha=generate_password_hash("admin123"),
+                senha=generate_password_hash("admin123", method="pbkdf2:sha256"),
                 formacao="Administrador de Sistemas",
                 tipo="superadmin"
             )
@@ -683,7 +683,7 @@ def criar_usuarios(clientes, quantidade=150):
                 nome=fake.name(),
                 cpf=cpf,
                 email=email,
-                senha=generate_password_hash(fake.password()),
+                senha=generate_password_hash(fake.password(), method="pbkdf2:sha256"),
                 formacao=random.choice(TIPOS_FORMACAO),
                 tipo=tipo,
                 estados=','.join(estados_usuario),
@@ -1123,7 +1123,7 @@ def criar_submissoes(eventos, usuarios, quantidade_por_evento=3):
         for _ in range(quantidade_por_evento):
             autor = random.choice(participantes)
             raw_code = fake.lexify(text="??????")
-            code_hash = generate_password_hash(raw_code)
+            code_hash = generate_password_hash(raw_code, method="pbkdf2:sha256")
             sub = Submission(
                 title=fake.sentence(nb_words=6),
                 abstract=fake.paragraph(),

--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -3591,7 +3591,7 @@ def cadastro_professor():
             nome=nome,
             email=email,
             cpf=cpf,
-            senha=generate_password_hash(senha),
+            senha=generate_password_hash(senha, method="pbkdf2:sha256"),
             formacao=formacao,
             tipo='professor'
         )
@@ -3760,7 +3760,7 @@ def adicionar_alunos():
                         nome=row['nome'],
                         cpf=cpf_str,
                         email=row['email'],
-                        senha=generate_password_hash(str(row['cpf'])),  # Senha inicial como CPF
+                        senha=generate_password_hash(str(row['cpf']), method="pbkdf2:sha256"),  # Senha inicial como CPF
                         formacao=row.get('formacao', 'Não informada'),
                         tipo='participante',
                         cliente_id=current_user.id  # Vincula ao cliente logado
@@ -3800,7 +3800,7 @@ def adicionar_alunos():
                     nome=nome,
                     cpf=cpf,
                     email=email,
-                    senha=generate_password_hash(cpf),  # Senha inicial como CPF
+                    senha=generate_password_hash(cpf, method="pbkdf2:sha256"),  # Senha inicial como CPF
                     formacao=formacao,
                     tipo='participante',
                     cliente_id=current_user.id,  # Vincula ao cliente logado
@@ -3905,7 +3905,7 @@ def importar_alunos():
                         nome=nome,
                         cpf=cpf,
                         email=email,
-                        senha=generate_password_hash(cpf),  # Senha inicial como CPF
+                        senha=generate_password_hash(cpf, method="pbkdf2:sha256"),  # Senha inicial como CPF
                         formacao=formacao,
                         tipo='participante',
                         cliente_id=current_user.id,  # Vincula ao cliente logado

--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -263,7 +263,7 @@ def reset_senha_cpf():
             flash('As senhas não coincidem ou não atendem aos requisitos.', 'danger')
             return redirect(url_for('auth_routes.reset_senha_cpf', token=token_str))
 
-        usuario.senha = generate_password_hash(nova_senha)
+        usuario.senha = generate_password_hash(nova_senha, method="pbkdf2:sha256")
         token_obj.used = True
         db.session.commit()
         flash('Senha redefinida com sucesso! Faça login novamente.', 'success')
@@ -420,7 +420,7 @@ def cadastrar_cliente_publico():
             novo_cliente = Cliente(
                 nome=nome,
                 email=email,
-                senha=generate_password_hash(senha),
+                senha=generate_password_hash(senha, method="pbkdf2:sha256"),
                 habilita_pagamento=True,
             )
 

--- a/routes/cliente_routes.py
+++ b/routes/cliente_routes.py
@@ -54,7 +54,7 @@ def cadastrar_cliente():
         novo_cliente = Cliente(
             nome=nome,
             email=email,
-            senha=generate_password_hash(senha),
+            senha=generate_password_hash(senha, method="pbkdf2:sha256"),
             habilita_pagamento=True,
         )
 
@@ -80,7 +80,7 @@ def editar_cliente(cliente_id):
         cliente.email = request.form.get("email")
         nova_senha = request.form.get("senha")
         if nova_senha:  # Só atualiza a senha se fornecida
-            cliente.senha = generate_password_hash(nova_senha)
+            cliente.senha = generate_password_hash(nova_senha, method="pbkdf2:sha256")
 
         # Pagamento sempre habilitado para clientes
         cliente.habilita_pagamento = True

--- a/routes/importar_trabalhos_routes.py
+++ b/routes/importar_trabalhos_routes.py
@@ -54,7 +54,7 @@ def importar_trabalhos():
                 title = str(raw_title)
             submission = Submission(
                 title=title,
-                code_hash=generate_password_hash(uuid.uuid4().hex),
+                code_hash=generate_password_hash(uuid.uuid4().hex, method="pbkdf2:sha256"),
                 evento_id=evento_id,
                 attributes=attributes,
             )

--- a/routes/importar_usuarios_routes.py
+++ b/routes/importar_usuarios_routes.py
@@ -52,7 +52,7 @@ def importar_usuarios():
                 if usuario_existente:
                     logger.warning("Usuário com CPF %s já existe. Pulando...", cpf_str)
                     continue
-                senha_hash = generate_password_hash(str(row["senha"]))
+                senha_hash = generate_password_hash(str(row["senha"]), method="pbkdf2:sha256")
                 novo_usuario = Usuario(
                     nome=row["nome"],
                     cpf=cpf_str,

--- a/routes/inscricao_routes.py
+++ b/routes/inscricao_routes.py
@@ -164,7 +164,7 @@ def _criar_usuario_e_inscricao(
             nome=nome,
             cpf=cpf,
             email=email,
-            senha=generate_password_hash(senha),
+            senha=generate_password_hash(senha, method="pbkdf2:sha256"),
             formacao=formacao,
             tipo="participante",
             cliente_id=cliente_id,
@@ -712,7 +712,7 @@ def editar_participante(usuario_id=None, oficina_id=None):
 
         nova_senha = sanitize_input(request.form.get('senha'))
         if nova_senha:
-            usuario.senha = generate_password_hash(nova_senha)
+            usuario.senha = generate_password_hash(nova_senha, method="pbkdf2:sha256")
 
         try:
             db.session.commit()

--- a/routes/ministrante_routes.py
+++ b/routes/ministrante_routes.py
@@ -36,7 +36,7 @@ def cadastro_ministrante():
         cidade = request.form.get('cidade')
         estado = request.form.get('estado')
         email = request.form.get('email')
-        senha = generate_password_hash(request.form.get('senha'))
+        senha = generate_password_hash(request.form.get('senha'), method="pbkdf2:sha256")
 
         # Se for admin, pega o cliente_id do form
         # Se for cliente, assume o id do current_user
@@ -123,7 +123,7 @@ def editar_ministrante(ministrante_id):
 
         nova_senha = request.form.get('senha')
         if nova_senha:
-            ministrante.senha = generate_password_hash(nova_senha)
+            ministrante.senha = generate_password_hash(nova_senha, method="pbkdf2:sha256")
 
         foto = request.files.get('foto')
         if foto and foto.filename:

--- a/routes/participante_routes.py
+++ b/routes/participante_routes.py
@@ -65,7 +65,7 @@ def editar_participante_admin(participante_id):
     participante.email = email
     participante.formacao = formacao
     if nova_senha:
-        participante.senha = generate_password_hash(nova_senha)
+        participante.senha = generate_password_hash(nova_senha, method="pbkdf2:sha256")
 
     db.session.commit()
     flash('Participante atualizado com sucesso!', 'success')

--- a/routes/peer_review_routes.py
+++ b/routes/peer_review_routes.py
@@ -675,7 +675,7 @@ def reviewer_registration():
                 nome=nome,
                 cpf=cpf,
                 email=email,
-                senha=generate_password_hash(senha),
+                senha=generate_password_hash(senha, method="pbkdf2:sha256"),
                 formacao=formacao,
                 tipo="revisor",
             )

--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -500,7 +500,7 @@ def approve(cand_id: int):
             reviewer = Usuario(
                 nome=cand.nome or cand.email,
                 email=cand.email,
-                senha=generate_password_hash("temp123"),
+                senha=generate_password_hash("temp123", method="pbkdf2:sha256"),
                 formacao="",
                 tipo="revisor",
             )

--- a/routes/submission_routes.py
+++ b/routes/submission_routes.py
@@ -35,7 +35,7 @@ def create_submission():
 
     locator = str(uuid.uuid4())
     raw_code = secrets.token_urlsafe(8)[:8]
-    code_hash = generate_password_hash(raw_code)
+    code_hash = generate_password_hash(raw_code, method="pbkdf2:sha256")
 
     submission = Submission(title=title, content=content,
                             locator=locator, code_hash=code_hash)

--- a/routes/trabalho_routes.py
+++ b/routes/trabalho_routes.py
@@ -142,7 +142,7 @@ def submeter_trabalho():
             author_id=current_user.id,
             evento_id=evento_id,
             status="submitted",
-            code_hash=generate_password_hash(code),
+            code_hash=generate_password_hash(code, method="pbkdf2:sha256"),
 
         )
         db.session.add(submission)

--- a/tests/test_agendamento_confirmacao.py
+++ b/tests/test_agendamento_confirmacao.py
@@ -45,7 +45,7 @@ def app():
         db.drop_all()
         db.create_all()
         cliente = Cliente(
-            nome='Cli', email='cli@test', senha=generate_password_hash('123')
+            nome='Cli', email='cli@test', senha=generate_password_hash('123', method="pbkdf2:sha256")
         )
         db.session.add(cliente)
         db.session.flush()
@@ -72,7 +72,7 @@ def app():
             nome='Prof',
             cpf='111',
             email='prof@test',
-            senha=generate_password_hash('p123'),
+            senha=generate_password_hash('p123', method="pbkdf2:sha256"),
             formacao='F',
             tipo='professor',
         )
@@ -80,7 +80,7 @@ def app():
             nome='Prof2',
             cpf='222',
             email='prof2@test',
-            senha=generate_password_hash('p123'),
+            senha=generate_password_hash('p123', method="pbkdf2:sha256"),
             formacao='F',
             tipo='professor',
         )

--- a/tests/test_agendamento_flow.py
+++ b/tests/test_agendamento_flow.py
@@ -150,7 +150,7 @@ def app():
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
     with app.app_context():
         db.create_all()
-        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('123'))
+        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('123', method="pbkdf2:sha256"))
         db.session.add(cliente)
         db.session.commit()
 
@@ -203,7 +203,7 @@ def app():
             nome='Prof',
             cpf='222',
             email='prof@test',
-            senha=generate_password_hash('p123'),
+            senha=generate_password_hash('p123', method="pbkdf2:sha256"),
             formacao='F',
             tipo='professor',
         )
@@ -211,7 +211,7 @@ def app():
             nome='Part',
             cpf='333',
             email='part@test',
-            senha=generate_password_hash('p123'),
+            senha=generate_password_hash('p123', method="pbkdf2:sha256"),
             formacao='F',
             tipo='participante',
         )

--- a/tests/test_assign_by_filters.py
+++ b/tests/test_assign_by_filters.py
@@ -38,7 +38,7 @@ def app():
         cliente = Cliente(
             nome='Cli',
             email='cli@example.com',
-            senha=generate_password_hash('123'),
+            senha=generate_password_hash('123', method="pbkdf2:sha256"),
         )
         db.session.add(cliente)
         db.session.commit()
@@ -68,7 +68,7 @@ def app():
                 nome='Rev',
                 cpf='1',
                 email='rev@example.com',
-                senha=generate_password_hash('123'),
+                senha=generate_password_hash('123', method="pbkdf2:sha256"),
                 formacao='',
                 tipo='revisor',
             )

--- a/tests/test_audit_log_resposta_deletion.py
+++ b/tests/test_audit_log_resposta_deletion.py
@@ -37,7 +37,7 @@ def app():
         cliente = Cliente(
             nome="Cli",
             email="cli@example.com",
-            senha=generate_password_hash("123"),
+            senha=generate_password_hash("123", method="pbkdf2:sha256"),
         )
         db.session.add(cliente)
         db.session.commit()
@@ -46,7 +46,7 @@ def app():
             nome="User",
             cpf="1",
             email="user@example.com",
-            senha=generate_password_hash("123"),
+            senha=generate_password_hash("123", method="pbkdf2:sha256"),
             formacao="x",
             tipo="participante",
             cliente_id=cliente.id,

--- a/tests/test_campo_routes.py
+++ b/tests/test_campo_routes.py
@@ -34,11 +34,11 @@ def login(client, email, senha):
 
 def test_adicionar_campo_personalizado_unauthorized(client, app):
     with app.app_context():
-        cliente = Cliente(nome='Cli', email='cli@example.com', senha=generate_password_hash('123'))
+        cliente = Cliente(nome='Cli', email='cli@example.com', senha=generate_password_hash('123', method="pbkdf2:sha256"))
         db.session.add(cliente)
         db.session.commit()
         evento = Evento(cliente_id=cliente.id, nome='EV')
-        user = Usuario(nome='User', cpf='1', email='u@example.com', senha=generate_password_hash('123'), formacao='x')
+        user = Usuario(nome='User', cpf='1', email='u@example.com', senha=generate_password_hash('123', method="pbkdf2:sha256"), formacao='x')
         db.session.add_all([user, evento])
         db.session.commit()
 
@@ -52,12 +52,12 @@ def test_adicionar_campo_personalizado_unauthorized(client, app):
 
 def test_remover_campo_personalizado_unauthorized(client, app):
     with app.app_context():
-        cliente = Cliente(nome='Cli', email='c@example.com', senha=generate_password_hash('123'))
+        cliente = Cliente(nome='Cli', email='c@example.com', senha=generate_password_hash('123', method="pbkdf2:sha256"))
         db.session.add(cliente)
         db.session.commit()
         evento = Evento(cliente_id=cliente.id, nome='EV')
         campo = CampoPersonalizadoCadastro(cliente_id=cliente.id, evento_id=evento.id, nome='C', tipo='texto')
-        user = Usuario(nome='User', cpf='2', email='user2@example.com', senha=generate_password_hash('123'), formacao='y')
+        user = Usuario(nome='User', cpf='2', email='user2@example.com', senha=generate_password_hash('123', method="pbkdf2:sha256"), formacao='y')
         db.session.add_all([evento, campo, user])
         db.session.commit()
         field_id = campo.id
@@ -72,7 +72,7 @@ def test_remover_campo_personalizado_unauthorized(client, app):
 
 def test_preview_certificado_logged_in(client, app):
     with app.app_context():
-        cliente = Cliente(nome='Cli', email='cli@example.com', senha=generate_password_hash('123'))
+        cliente = Cliente(nome='Cli', email='cli@example.com', senha=generate_password_hash('123', method="pbkdf2:sha256"))
         db.session.add(cliente)
         db.session.commit()
         cid = cliente.id
@@ -102,7 +102,7 @@ import pytest
 def test_toggle_default_fields(client, app, route, field, default, event_based):
     with app.app_context():
         # Cria cliente e evento
-        cliente = Cliente(nome='Cli', email='toggler@example.com', senha=generate_password_hash('123'))
+        cliente = Cliente(nome='Cli', email='toggler@example.com', senha=generate_password_hash('123', method="pbkdf2:sha256"))
         db.session.add(cliente)
         db.session.commit()
         evento = Evento(cliente_id=cliente.id, nome='EV')
@@ -141,7 +141,7 @@ def test_toggle_default_fields(client, app, route, field, default, event_based):
 ])
 def test_toggle_event_isolated(client, app, route, field, default):
     with app.app_context():
-        cliente = Cliente(nome='Cli', email='iso@example.com', senha=generate_password_hash('123'))
+        cliente = Cliente(nome='Cli', email='iso@example.com', senha=generate_password_hash('123', method="pbkdf2:sha256"))
         db.session.add(cliente)
         db.session.commit()
         evento1 = Evento(cliente_id=cliente.id, nome='EV1')

--- a/tests/test_checkin_routes.py
+++ b/tests/test_checkin_routes.py
@@ -141,7 +141,7 @@ def app():
     with app.app_context():
         db.create_all()
         cliente = Cliente(
-            nome="Cli", email="cli@test", senha=generate_password_hash("123")
+            nome="Cli", email="cli@test", senha=generate_password_hash("123", method="pbkdf2:sha256")
         )
         db.session.add(cliente)
         db.session.flush()
@@ -167,7 +167,7 @@ def app():
             nome="Prof",
             cpf="111",
             email="prof@test",
-            senha=generate_password_hash("p123"),
+            senha=generate_password_hash("p123", method="pbkdf2:sha256"),
             formacao="F",
             tipo="professor",
         )
@@ -279,7 +279,7 @@ def test_confirmar_checkin_redirect_outro_usuario(client, app):
             nome="Admin",
             cpf="0",
             email="admin@test",
-            senha=generate_password_hash("123"),
+            senha=generate_password_hash("123", method="pbkdf2:sha256"),
             formacao="X",
             tipo="admin",
         )

--- a/tests/test_client_quota_limits.py
+++ b/tests/test_client_quota_limits.py
@@ -17,7 +17,7 @@ def app():
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
     with app.app_context():
         db.create_all()
-        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('123'))
+        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('123', method="pbkdf2:sha256"))
         db.session.add(cliente)
         db.session.commit()
         db.session.add(ConfiguracaoCliente(cliente_id=cliente.id, limite_eventos=1, limite_formularios=1))

--- a/tests/test_cliente_admin_auth.py
+++ b/tests/test_cliente_admin_auth.py
@@ -53,10 +53,10 @@ def app():
 
     with app.app_context():
         db.create_all()
-        admin = Usuario(nome='Admin', cpf='1', email='admin@test', senha=generate_password_hash('123'), formacao='x', tipo='admin')
-        user1 = Usuario(nome='User1', cpf='2', email='user@test', senha=generate_password_hash('123'), formacao='y')
-        user2 = Usuario(nome='User2', cpf='3', email='other@test', senha=generate_password_hash('123'), formacao='z')
-        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('456'))
+        admin = Usuario(nome='Admin', cpf='1', email='admin@test', senha=generate_password_hash('123', method="pbkdf2:sha256"), formacao='x', tipo='admin')
+        user1 = Usuario(nome='User1', cpf='2', email='user@test', senha=generate_password_hash('123', method="pbkdf2:sha256"), formacao='y')
+        user2 = Usuario(nome='User2', cpf='3', email='other@test', senha=generate_password_hash('123', method="pbkdf2:sha256"), formacao='z')
+        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('456', method="pbkdf2:sha256"))
         db.session.add_all([admin, user1, user2, cliente])
         db.session.commit()
     yield app

--- a/tests/test_config_cliente_review.py
+++ b/tests/test_config_cliente_review.py
@@ -25,7 +25,7 @@ def app():
     app.config['WTF_CSRF_ENABLED'] = False
     with app.app_context():
         db.create_all()
-        cliente = Cliente(nome='Cli', email='cli@example.com', senha=generate_password_hash('123'))
+        cliente = Cliente(nome='Cli', email='cli@example.com', senha=generate_password_hash('123', method="pbkdf2:sha256"))
         db.session.add(cliente)
         db.session.commit()
         db.session.add(ConfiguracaoCliente(cliente_id=cliente.id))

--- a/tests/test_config_event_route.py
+++ b/tests/test_config_event_route.py
@@ -30,7 +30,7 @@ def login(client, email, senha):
 
 def test_configuracao_evento_defaults(client, app):
     with app.app_context():
-        cliente = Cliente(nome='Cli', email='cli@example.com', senha=generate_password_hash('123'))
+        cliente = Cliente(nome='Cli', email='cli@example.com', senha=generate_password_hash('123', method="pbkdf2:sha256"))
         db.session.add(cliente)
         db.session.commit()
         evento = Evento(cliente_id=cliente.id, nome='EV')

--- a/tests/test_dashboard_cliente_db_error.py
+++ b/tests/test_dashboard_cliente_db_error.py
@@ -23,7 +23,7 @@ def app():
     with app.app_context():
         db.create_all()
         cliente = Cliente(
-            nome="Cli", email="cli@test", senha=generate_password_hash("123")
+            nome="Cli", email="cli@test", senha=generate_password_hash("123", method="pbkdf2:sha256")
         )
         db.session.add(cliente)
         db.session.commit()
@@ -34,7 +34,7 @@ def app():
             nome="CliUser",
             cpf="1",
             email="cli@test",
-            senha=generate_password_hash("123"),
+            senha=generate_password_hash("123", method="pbkdf2:sha256"),
             formacao="x",
             tipo="cliente",
         )

--- a/tests/test_dashboard_cliente_preview.py
+++ b/tests/test_dashboard_cliente_preview.py
@@ -24,7 +24,7 @@ def app():
     with app.app_context():
         db.create_all()
         cliente = Cliente(
-            nome="Cli", email="cli@test", senha=generate_password_hash("123")
+            nome="Cli", email="cli@test", senha=generate_password_hash("123", method="pbkdf2:sha256")
         )
         db.session.add(cliente)
         db.session.commit()
@@ -35,7 +35,7 @@ def app():
             nome="CliUser",
             cpf="1",
             email="cli@test",
-            senha=generate_password_hash("123"),
+            senha=generate_password_hash("123", method="pbkdf2:sha256"),
             formacao="x",
             tipo="cliente",
         )

--- a/tests/test_dashboard_participante_event_selection.py
+++ b/tests/test_dashboard_participante_event_selection.py
@@ -71,8 +71,8 @@ def app():
 
     with app.app_context():
         db.create_all()
-        c1 = Cliente(nome='C1', email='c1@test', senha=generate_password_hash('1'))
-        c2 = Cliente(nome='C2', email='c2@test', senha=generate_password_hash('1'))
+        c1 = Cliente(nome='C1', email='c1@test', senha=generate_password_hash('1', method="pbkdf2:sha256"))
+        c2 = Cliente(nome='C2', email='c2@test', senha=generate_password_hash('1', method="pbkdf2:sha256"))
         db.session.add_all([c1, c2])
         db.session.commit()
         ev1 = Evento(cliente_id=c2.id, nome='Event1', inscricao_gratuita=True, publico=True, data_inicio=date(2024,1,1))
@@ -80,7 +80,7 @@ def app():
         db.session.add_all([ev1, ev2])
         db.session.commit()
         user = Usuario(
-            nome='U', cpf='1', email='p@test', senha=generate_password_hash('123'),
+            nome='U', cpf='1', email='p@test', senha=generate_password_hash('123', method="pbkdf2:sha256"),
             formacao='x', tipo='participante', cliente_id=c1.id
         )
         db.session.add(user)

--- a/tests/test_dashboard_participante_public_event.py
+++ b/tests/test_dashboard_participante_public_event.py
@@ -72,8 +72,8 @@ def app():
 
     with app.app_context():
         db.create_all()
-        c1 = Cliente(nome='C1', email='c1@test', senha=generate_password_hash('1'))
-        c2 = Cliente(nome='C2', email='c2@test', senha=generate_password_hash('1'))
+        c1 = Cliente(nome='C1', email='c1@test', senha=generate_password_hash('1', method="pbkdf2:sha256"))
+        c2 = Cliente(nome='C2', email='c2@test', senha=generate_password_hash('1', method="pbkdf2:sha256"))
         db.session.add_all([c1, c2])
         db.session.commit()
         ev = Evento(cliente_id=c2.id, nome='Public Event', inscricao_gratuita=True, publico=True)
@@ -89,7 +89,7 @@ def app():
         dia = OficinaDia(oficina_id=ofi.id, data=date.today(), horario_inicio='08:00', horario_fim='10:00')
         db.session.add(dia)
         user = Usuario(
-            nome='U', cpf='1', email='p@test', senha=generate_password_hash('123'),
+            nome='U', cpf='1', email='p@test', senha=generate_password_hash('123', method="pbkdf2:sha256"),
             formacao='x', tipo='participante', cliente_id=c1.id
         )
         db.session.add(user)

--- a/tests/test_event_client_deletion.py
+++ b/tests/test_event_client_deletion.py
@@ -35,11 +35,11 @@ def app():
         db.create_all()
         admin = Usuario(
             nome='Admin', cpf='1', email='admin@example.com',
-            senha=generate_password_hash('123'), formacao='x', tipo='admin'
+            senha=generate_password_hash('123', method="pbkdf2:sha256"), formacao='x', tipo='admin'
         )
         db.session.add(admin)
         cliente = Cliente(
-            nome='Cli', email='cli@example.com', senha=generate_password_hash('456')
+            nome='Cli', email='cli@example.com', senha=generate_password_hash('456', method="pbkdf2:sha256")
         )
         db.session.add(cliente)
         db.session.commit()
@@ -75,7 +75,7 @@ def _setup_event_with_payment(app, cliente):
         db.session.add(tipo)
         usuario = Usuario(
             nome='Part', cpf='2', email='p@example.com',
-            senha=generate_password_hash('123'), formacao='x', tipo='participante',
+            senha=generate_password_hash('123', method="pbkdf2:sha256"), formacao='x', tipo='participante',
             cliente_id=cliente.id
         )
         db.session.add(usuario)
@@ -134,7 +134,7 @@ def test_excluir_cliente_cleans_association(client, app):
         cliente = Cliente.query.first()
         user = Usuario(
             nome='User', cpf='99', email='u@example.com',
-            senha=generate_password_hash('123'), formacao='x', tipo='participante'
+            senha=generate_password_hash('123', method="pbkdf2:sha256"), formacao='x', tipo='participante'
         )
         db.session.add(user)
         db.session.commit()
@@ -189,7 +189,7 @@ def test_excluir_cliente_remove_reset_tokens(client, app):
             nome="ResetUser",
             cpf="3",
             email="reset@example.com",
-            senha=generate_password_hash("123"),
+            senha=generate_password_hash("123", method="pbkdf2:sha256"),
             formacao="x",
             tipo="participante",
             cliente_id=cliente.id,

--- a/tests/test_evento_arquivar.py
+++ b/tests/test_evento_arquivar.py
@@ -19,7 +19,7 @@ def app():
 
     with app.app_context():
         db.create_all()
-        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('123'))
+        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('123', method="pbkdf2:sha256"))
         db.session.add(cliente)
         db.session.commit()
         evento = Evento(cliente_id=cliente.id, nome='EV')

--- a/tests/test_evento_submissao.py
+++ b/tests/test_evento_submissao.py
@@ -23,7 +23,7 @@ def app():
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
     with app.app_context():
         db.create_all()
-        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('123'))
+        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('123', method="pbkdf2:sha256"))
         db.session.add(cliente)
         db.session.commit()
         evento = Evento(cliente_id=cliente.id, nome='EV', submissao_aberta=False)
@@ -33,7 +33,7 @@ def app():
             nome='Part',
             cpf='1',
             email='part@test',
-            senha=generate_password_hash('123'),
+            senha=generate_password_hash('123', method="pbkdf2:sha256"),
             formacao='x',
             tipo='participante',
             cliente_id=cliente.id,

--- a/tests/test_formulario_delete.py
+++ b/tests/test_formulario_delete.py
@@ -35,7 +35,7 @@ def app():
         cliente = Cliente(
             nome="Cli",
             email="cli@test",
-            senha=generate_password_hash("123"),
+            senha=generate_password_hash("123", method="pbkdf2:sha256"),
         )
         db.session.add(cliente)
         db.session.commit()
@@ -54,7 +54,7 @@ def app():
             nome="User",
             cpf="00000000000000",
             email="user@test",
-            senha=generate_password_hash("123"),
+            senha=generate_password_hash("123", method="pbkdf2:sha256"),
             formacao="None",
         )
         db.session.add(usuario)

--- a/tests/test_formulario_evento_crossclient.py
+++ b/tests/test_formulario_evento_crossclient.py
@@ -25,8 +25,8 @@ def app():
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
     with app.app_context():
         db.create_all()
-        c1 = Cliente(nome='C1', email='c1@test', senha=generate_password_hash('123'))
-        c2 = Cliente(nome='C2', email='c2@test', senha=generate_password_hash('123'))
+        c1 = Cliente(nome='C1', email='c1@test', senha=generate_password_hash('123', method="pbkdf2:sha256"))
+        c2 = Cliente(nome='C2', email='c2@test', senha=generate_password_hash('123', method="pbkdf2:sha256"))
         db.session.add_all([c1, c2])
         db.session.commit()
         e1 = Evento(cliente_id=c1.id, nome='E1', inscricao_gratuita=True, publico=True)

--- a/tests/test_formulario_eventos.py
+++ b/tests/test_formulario_eventos.py
@@ -26,7 +26,7 @@ def app():
     with app.app_context():
         db.create_all()
         cliente = Cliente(
-            nome="Cli", email="cli@test", senha=generate_password_hash("123")
+            nome="Cli", email="cli@test", senha=generate_password_hash("123", method="pbkdf2:sha256")
         )
         db.session.add(cliente)
         db.session.commit()

--- a/tests/test_formulario_participante_crossclient.py
+++ b/tests/test_formulario_participante_crossclient.py
@@ -18,8 +18,8 @@ def app():
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
     with app.app_context():
         db.create_all()
-        c1 = Cliente(nome='C1', email='c1@test', senha=generate_password_hash('123'))
-        c2 = Cliente(nome='C2', email='c2@test', senha=generate_password_hash('123'))
+        c1 = Cliente(nome='C1', email='c1@test', senha=generate_password_hash('123', method="pbkdf2:sha256"))
+        c2 = Cliente(nome='C2', email='c2@test', senha=generate_password_hash('123', method="pbkdf2:sha256"))
         db.session.add_all([c1, c2])
         db.session.commit()
         f1 = Formulario(nome='F1', cliente_id=c1.id)
@@ -29,8 +29,8 @@ def app():
         db.session.commit()
         ev.formularios.append(f2)
         db.session.commit()
-        p1 = Usuario(nome='Part1', cpf='1', email='p1@test', senha=generate_password_hash('123'), formacao='x', tipo='participante', cliente_id=c1.id, evento_id=ev.id)
-        p2 = Usuario(nome='Part2', cpf='2', email='p2@test', senha=generate_password_hash('123'), formacao='x', tipo='participante', cliente_id=c1.id)
+        p1 = Usuario(nome='Part1', cpf='1', email='p1@test', senha=generate_password_hash('123', method="pbkdf2:sha256"), formacao='x', tipo='participante', cliente_id=c1.id, evento_id=ev.id)
+        p2 = Usuario(nome='Part2', cpf='2', email='p2@test', senha=generate_password_hash('123', method="pbkdf2:sha256"), formacao='x', tipo='participante', cliente_id=c1.id)
         db.session.add_all([p1, p2])
         db.session.commit()
     yield app

--- a/tests/test_formulario_vinculo_revisor.py
+++ b/tests/test_formulario_vinculo_revisor.py
@@ -23,7 +23,7 @@ def app():
     with app.app_context():
         db.create_all()
         cliente = Cliente(
-            nome='Cli', email='cli@test', senha=generate_password_hash('123')
+            nome='Cli', email='cli@test', senha=generate_password_hash('123', method="pbkdf2:sha256")
         )
         db.session.add(cliente)
         db.session.commit()

--- a/tests/test_impersonation.py
+++ b/tests/test_impersonation.py
@@ -16,9 +16,9 @@ def app():
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
     with app.app_context():
         db.create_all()
-        admin = Usuario(nome='Admin', cpf='1', email='admin@test', senha=generate_password_hash('123'), formacao='x', tipo='admin')
+        admin = Usuario(nome='Admin', cpf='1', email='admin@test', senha=generate_password_hash('123', method="pbkdf2:sha256"), formacao='x', tipo='admin')
         db.session.add(admin)
-        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('456'))
+        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('456', method="pbkdf2:sha256"))
         db.session.add(cliente)
         db.session.commit()
     yield app

--- a/tests/test_inscricao_helpers.py
+++ b/tests/test_inscricao_helpers.py
@@ -105,7 +105,7 @@ def test_criar_usuario_e_inscricao_errors(app_ctx):
         nome='Bob',
         cpf='222',
         email='bob@example.com',
-        senha=generate_password_hash('secret'),
+        senha=generate_password_hash('secret', method="pbkdf2:sha256"),
         formacao='F',
     )
     db.session.add(user)

--- a/tests/test_password_reset.py
+++ b/tests/test_password_reset.py
@@ -25,7 +25,7 @@ def app():
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
     with app.app_context():
         db.create_all()
-        user = Usuario(nome='User', cpf='123', email='user@test', senha=generate_password_hash('123'), formacao='F')
+        user = Usuario(nome='User', cpf='123', email='user@test', senha=generate_password_hash('123', method="pbkdf2:sha256"), formacao='F')
         db.session.add(user)
         db.session.commit()
     yield app

--- a/tests/test_pdf_routes_admin.py
+++ b/tests/test_pdf_routes_admin.py
@@ -21,9 +21,9 @@ def app():
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
     with app.app_context():
         db.create_all()
-        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('123'))
-        admin = Usuario(nome='Admin', cpf='1', email='admin@test', senha=generate_password_hash('123'), formacao='x', tipo='admin')
-        usuario = Usuario(nome='User', cpf='2', email='user@test', senha=generate_password_hash('123'), formacao='x')
+        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('123', method="pbkdf2:sha256"))
+        admin = Usuario(nome='Admin', cpf='1', email='admin@test', senha=generate_password_hash('123', method="pbkdf2:sha256"), formacao='x', tipo='admin')
+        usuario = Usuario(nome='User', cpf='2', email='user@test', senha=generate_password_hash('123', method="pbkdf2:sha256"), formacao='x')
         db.session.add_all([cliente, admin, usuario])
         db.session.commit()
         oficina = Oficina(titulo='Of', descricao='desc', ministrante_id=None, vagas=10, carga_horaria='8', estado='SP', cidade='SP', cliente_id=cliente.id)

--- a/tests/test_peer_review_barema.py
+++ b/tests/test_peer_review_barema.py
@@ -42,7 +42,7 @@ def app():
     app.register_blueprint(peer_review_routes)
     with app.app_context():
         db.create_all()
-        cliente = Cliente(nome="Cli", email="cli@test", senha=generate_password_hash("123"))
+        cliente = Cliente(nome="Cli", email="cli@test", senha=generate_password_hash("123", method="pbkdf2:sha256"))
         db.session.add(cliente)
         db.session.flush()
         evento = Evento(cliente_id=cliente.id, nome="Evento", inscricao_gratuita=True)
@@ -50,14 +50,14 @@ def app():
             nome="Rev",
             cpf="1",
             email="rev@test",
-            senha=generate_password_hash("123"),
+            senha=generate_password_hash("123", method="pbkdf2:sha256"),
             formacao="X",
             tipo="professor",
         )
         submission = Submission(
             title="T",
             content="Body",
-            code_hash=generate_password_hash("code"),
+            code_hash=generate_password_hash("code", method="pbkdf2:sha256"),
             evento_id=evento.id,
         )
         db.session.add_all([evento, reviewer, submission])

--- a/tests/test_peer_review_flow.py
+++ b/tests/test_peer_review_flow.py
@@ -79,13 +79,13 @@ def app():
     with app.app_context():
         db.create_all()
         cliente = Cliente(
-            nome="Cli", email="cli@test", senha=generate_password_hash("123")
+            nome="Cli", email="cli@test", senha=generate_password_hash("123", method="pbkdf2:sha256")
         )
         admin = Usuario(
             nome="Admin",
             cpf="1",
             email="admin@test",
-            senha=generate_password_hash("123"),
+            senha=generate_password_hash("123", method="pbkdf2:sha256"),
             formacao="x",
             tipo="admin",
         )
@@ -93,7 +93,7 @@ def app():
             nome="Rev",
             cpf="2",
             email="rev@test",
-            senha=generate_password_hash("123"),
+            senha=generate_password_hash("123", method="pbkdf2:sha256"),
             formacao="x",
             tipo="revisor",
         )
@@ -101,7 +101,7 @@ def app():
             nome="RevBad",
             cpf="4",
             email="revbad@test",
-            senha=generate_password_hash("123"),
+            senha=generate_password_hash("123", method="pbkdf2:sha256"),
             formacao="x",
             tipo="revisor",
         )
@@ -109,7 +109,7 @@ def app():
             nome="Author",
             cpf="3",
             email="author@test",
-            senha=generate_password_hash("123"),
+            senha=generate_password_hash("123", method="pbkdf2:sha256"),
             formacao="x",
             tipo="participante",
         )

--- a/tests/test_professor_routes_access.py
+++ b/tests/test_professor_routes_access.py
@@ -51,7 +51,7 @@ def app(monkeypatch):
         cliente = Cliente(
             nome='Cliente',
             email='cli@test',
-            senha=generate_password_hash('123'),
+            senha=generate_password_hash('123', method="pbkdf2:sha256"),
         )
         db.session.add(cliente)
 
@@ -59,7 +59,7 @@ def app(monkeypatch):
             nome='Prof',
             cpf='1',
             email='prof@test',
-            senha=generate_password_hash('123'),
+            senha=generate_password_hash('123', method="pbkdf2:sha256"),
             formacao='x',
             tipo='professor',
         )
@@ -67,7 +67,7 @@ def app(monkeypatch):
             nome='Part',
             cpf='2',
             email='part@test',
-            senha=generate_password_hash('123'),
+            senha=generate_password_hash('123', method="pbkdf2:sha256"),
             formacao='x',
             tipo='participante',
         )
@@ -75,7 +75,7 @@ def app(monkeypatch):
             nome='User',
             cpf='3',
             email='user@test',
-            senha=generate_password_hash('123'),
+            senha=generate_password_hash('123', method="pbkdf2:sha256"),
             formacao='x',
             tipo='usuario',
         )

--- a/tests/test_relatorio_geral_agendamentos.py
+++ b/tests/test_relatorio_geral_agendamentos.py
@@ -107,7 +107,7 @@ def app():
     with app.app_context():
         db.create_all()
         cliente = Cliente(
-            nome='Cli', email='cli@test', senha=generate_password_hash('123')
+            nome='Cli', email='cli@test', senha=generate_password_hash('123', method="pbkdf2:sha256")
         )
         db.session.add(cliente)
         db.session.commit()
@@ -128,7 +128,7 @@ def app():
             nome='Prof',
             cpf='00000000000',
             email='prof@test',
-            senha=generate_password_hash('123'),
+            senha=generate_password_hash('123', method="pbkdf2:sha256"),
             formacao='x',
             tipo='professor',
         )

--- a/tests/test_relatorio_geral_agendamentos_date_formats.py
+++ b/tests/test_relatorio_geral_agendamentos_date_formats.py
@@ -43,7 +43,7 @@ def app():
         cliente = Cliente(
             nome='Cli',
             email='cli@test',
-            senha=generate_password_hash('123'),
+            senha=generate_password_hash('123', method="pbkdf2:sha256"),
         )
         db.session.add(cliente)
         db.session.commit()

--- a/tests/test_relatorio_pdf_routes.py
+++ b/tests/test_relatorio_pdf_routes.py
@@ -29,8 +29,8 @@ def app():
     app.config['WTF_CSRF_ENABLED'] = False
     with app.app_context():
         db.create_all()
-        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('123'))
-        admin = Usuario(nome='Admin', cpf='1', email='admin@test', senha=generate_password_hash('123'), formacao='x', tipo='admin')
+        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('123', method="pbkdf2:sha256"))
+        admin = Usuario(nome='Admin', cpf='1', email='admin@test', senha=generate_password_hash('123', method="pbkdf2:sha256"), formacao='x', tipo='admin')
         db.session.add_all([cliente, admin])
         db.session.commit()
         evento = Evento(cliente_id=cliente.id, nome='Evento')

--- a/tests/test_relatorio_routes.py
+++ b/tests/test_relatorio_routes.py
@@ -29,7 +29,7 @@ def app():
         db.create_all()
         admin = Usuario(
             nome='Admin', cpf='1', email='admin@test',
-            senha=generate_password_hash('123'), formacao='x', tipo='admin'
+            senha=generate_password_hash('123', method="pbkdf2:sha256"), formacao='x', tipo='admin'
         )
         db.session.add(admin)
         db.session.commit()

--- a/tests/test_requisito_validation.py
+++ b/tests/test_requisito_validation.py
@@ -54,7 +54,7 @@ def app():
         cliente = Cliente(
             nome="C",
             email="c@test",
-            senha=generate_password_hash("123"),
+            senha=generate_password_hash("123", method="pbkdf2:sha256"),
         )
         db.session.add(cliente)
         db.session.commit()

--- a/tests/test_review_tracking.py
+++ b/tests/test_review_tracking.py
@@ -16,7 +16,7 @@ def app():
     with app.app_context():
         db.create_all()
         raw_code = 'secret'
-        sub = Submission(title='T', locator='loc1', code_hash=generate_password_hash(raw_code))
+        sub = Submission(title='T', locator='loc1', code_hash=generate_password_hash(raw_code, method="pbkdf2:sha256"))
         db.session.add(sub)
         db.session.commit()
         rev = Review(submission_id=sub.id, locator='revloc', access_code='revcode')

--- a/tests/test_reviewer_applications.py
+++ b/tests/test_reviewer_applications.py
@@ -87,9 +87,9 @@ def app():
     app.config['WTF_CSRF_ENABLED'] = False
     with app.app_context():
         db.create_all()
-        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('123'))
-        admin = Usuario(nome='Admin', cpf='1', email='admin@test', senha=generate_password_hash('123'), formacao='x', tipo='admin')
-        user = Usuario(nome='User', cpf='2', email='user@test', senha=generate_password_hash('123'), formacao='x')
+        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('123', method="pbkdf2:sha256"))
+        admin = Usuario(nome='Admin', cpf='1', email='admin@test', senha=generate_password_hash('123', method="pbkdf2:sha256"), formacao='x', tipo='admin')
+        user = Usuario(nome='User', cpf='2', email='user@test', senha=generate_password_hash('123', method="pbkdf2:sha256"), formacao='x')
         db.session.add_all([cliente, admin, user])
         db.session.commit()
         db.session.add(ReviewerApplication(usuario_id=user.id))
@@ -159,7 +159,7 @@ def test_submit_application_and_visibility(client, app):
     with app.app_context():
         new_user = Usuario(
             nome='Applicant', cpf='3', email='app@test',
-            senha=generate_password_hash('123'), formacao='x'
+            senha=generate_password_hash('123', method="pbkdf2:sha256"), formacao='x'
         )
         db.session.add(new_user)
         db.session.commit()
@@ -237,7 +237,7 @@ def test_approve_revisor_cpf_collision(client, app, monkeypatch):
             nome='Exist',
             cpf='12345678901',
             email='exist@test',
-            senha=generate_password_hash('123'),
+            senha=generate_password_hash('123', method="pbkdf2:sha256"),
             formacao='x',
         )
         db.session.add(existing)
@@ -284,7 +284,7 @@ def test_approve_revisor_cpf_collision_error(client, app, monkeypatch, caplog):
             nome='Exist',
             cpf='12345678901',
             email='exist@test',
-            senha=generate_password_hash('123'),
+            senha=generate_password_hash('123', method="pbkdf2:sha256"),
             formacao='x',
         )
         db.session.add(existing)

--- a/tests/test_reviewer_registration.py
+++ b/tests/test_reviewer_registration.py
@@ -30,7 +30,7 @@ def app():
     app.config['WTF_CSRF_ENABLED'] = False
     with app.app_context():
         db.create_all()
-        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('123'))
+        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('123', method="pbkdf2:sha256"))
         db.session.add(cliente)
         db.session.commit()
     return app

--- a/tests/test_revisor_avaliacao_intervalo.py
+++ b/tests/test_revisor_avaliacao_intervalo.py
@@ -35,7 +35,7 @@ def app():
     with app.app_context():
         db.create_all()
         cliente = Cliente(
-            nome="C", email="c@test", senha=generate_password_hash("123")
+            nome="C", email="c@test", senha=generate_password_hash("123", method="pbkdf2:sha256")
         )
         db.session.add(cliente)
         db.session.flush()
@@ -45,13 +45,13 @@ def app():
             nome="Rev",
             cpf="1",
             email="rev@test",
-            senha=generate_password_hash("123"),
+            senha=generate_password_hash("123", method="pbkdf2:sha256"),
             formacao="X",
             tipo="revisor",
         )
         submission = Submission(
             title="T",
-            code_hash=generate_password_hash("code"),
+            code_hash=generate_password_hash("code", method="pbkdf2:sha256"),
             evento_id=evento.id,
         )
         db.session.add_all([evento, reviewer, submission])

--- a/tests/test_revisor_avaliar_assignment.py
+++ b/tests/test_revisor_avaliar_assignment.py
@@ -26,12 +26,12 @@ def app():
     with app.app_context():
         db.create_all()
         reviewer = Usuario(
-            nome="Rev", cpf="1", email="rev@test", senha=generate_password_hash("123"),
+            nome="Rev", cpf="1", email="rev@test", senha=generate_password_hash("123", method="pbkdf2:sha256"),
             formacao="X", tipo="revisor"
         )
         submission = Submission(
             title="T",
-            code_hash=generate_password_hash("code"),
+            code_hash=generate_password_hash("code", method="pbkdf2:sha256"),
         )
         db.session.add_all([reviewer, submission])
         db.session.commit()

--- a/tests/test_revisor_email_notifications.py
+++ b/tests/test_revisor_email_notifications.py
@@ -65,7 +65,7 @@ def app():
     with app.app_context():
         db.create_all()
         cliente = Cliente(
-            nome='Cli', email='cli@test', senha=generate_password_hash('123')
+            nome='Cli', email='cli@test', senha=generate_password_hash('123', method="pbkdf2:sha256")
         )
         db.session.add(cliente)
         db.session.commit()

--- a/tests/test_revisor_process.py
+++ b/tests/test_revisor_process.py
@@ -81,7 +81,7 @@ def app():
         except SystemExit:
             db.create_all()
         cliente = Cliente(
-            nome="Cli", email="cli@test", senha=generate_password_hash("123")
+            nome="Cli", email="cli@test", senha=generate_password_hash("123", method="pbkdf2:sha256")
         )
         db.session.add(cliente)
         db.session.commit()
@@ -128,7 +128,7 @@ def app():
             nome="Part",
             cpf="3",
             email="part@test",
-            senha=generate_password_hash("123"),
+            senha=generate_password_hash("123", method="pbkdf2:sha256"),
             formacao="x",
             tipo="participante",
         )

--- a/tests/test_revisor_process_extra.py
+++ b/tests/test_revisor_process_extra.py
@@ -41,8 +41,8 @@ def app():
             upgrade(revision="heads")
         except SystemExit:
             db.create_all()
-        c1 = Cliente(nome='C1', email='c1@test', senha=generate_password_hash('123'))
-        c2 = Cliente(nome='C2', email='c2@test', senha=generate_password_hash('123'))
+        c1 = Cliente(nome='C1', email='c1@test', senha=generate_password_hash('123', method="pbkdf2:sha256"))
+        c2 = Cliente(nome='C2', email='c2@test', senha=generate_password_hash('123', method="pbkdf2:sha256"))
         db.session.add_all([c1, c2])
         db.session.commit()
         f1 = Formulario(nome='F1', cliente_id=c1.id)

--- a/tests/test_revisor_score_limits.py
+++ b/tests/test_revisor_score_limits.py
@@ -40,7 +40,7 @@ def app():
         cliente = Cliente(
             nome="Cli",
             email="cli@test",
-            senha=generate_password_hash("123"),
+            senha=generate_password_hash("123", method="pbkdf2:sha256"),
         )
         db.session.add(cliente)
         db.session.flush()
@@ -48,7 +48,7 @@ def app():
             nome="Rev",
             cpf="1",
             email="rev@test",
-            senha=generate_password_hash("123"),
+            senha=generate_password_hash("123", method="pbkdf2:sha256"),
             formacao="X",
             tipo="revisor",
         )
@@ -75,7 +75,7 @@ def app():
         evento_barema = EventoBarema(evento_id=evento.id, requisitos={"Qualidade": 5})
         submission = Submission(
             title="T",
-            code_hash=generate_password_hash("code"),
+            code_hash=generate_password_hash("code", method="pbkdf2:sha256"),
             evento_id=evento.id,
         )
         assignment = Assignment(submission=submission, reviewer=reviewer)

--- a/tests/test_revisor_select_event_filter.py
+++ b/tests/test_revisor_select_event_filter.py
@@ -48,7 +48,7 @@ def app():
     app.register_blueprint(evento_routes)
     with app.app_context():
         db.create_all()
-        cliente = Cliente(nome="C", email="c@test", senha=generate_password_hash("123"))
+        cliente = Cliente(nome="C", email="c@test", senha=generate_password_hash("123", method="pbkdf2:sha256"))
         db.session.add(cliente)
         db.session.commit()
         form = Formulario(nome="F", cliente_id=cliente.id)

--- a/tests/test_sortear_revisores.py
+++ b/tests/test_sortear_revisores.py
@@ -35,7 +35,7 @@ def app():
         cliente = Cliente(
             nome='Cli',
             email='cli@example.com',
-            senha=generate_password_hash('123'),
+            senha=generate_password_hash('123', method="pbkdf2:sha256"),
         )
         db.session.add(cliente)
         db.session.commit()
@@ -74,7 +74,7 @@ def app():
                 nome='Rev1',
                 cpf='1',
                 email='rev1@example.com',
-                senha=generate_password_hash('123'),
+                senha=generate_password_hash('123', method="pbkdf2:sha256"),
                 formacao='',
                 tipo='revisor',
             )
@@ -84,7 +84,7 @@ def app():
                 nome='Rev2',
                 cpf='2',
                 email='rev2@example.com',
-                senha=generate_password_hash('123'),
+                senha=generate_password_hash('123', method="pbkdf2:sha256"),
                 formacao='',
                 tipo='revisor',
             )

--- a/tests/test_submission_control_reviewers.py
+++ b/tests/test_submission_control_reviewers.py
@@ -32,14 +32,14 @@ def app():
             nome='Admin',
             cpf='1',
             email='admin@test',
-            senha=generate_password_hash('123'),
+            senha=generate_password_hash('123', method="pbkdf2:sha256"),
             formacao='',
             tipo='admin',
         )
         cliente = Cliente(
             nome='Cli',
             email='cli@test',
-            senha=generate_password_hash('123'),
+            senha=generate_password_hash('123', method="pbkdf2:sha256"),
         )
         db.session.add_all([admin, cliente])
         db.session.flush()
@@ -52,7 +52,7 @@ def app():
                     nome='Aprovado',
                     cpf='2',
                     email='aprovado@test',
-                    senha=generate_password_hash('123'),
+                    senha=generate_password_hash('123', method="pbkdf2:sha256"),
                     formacao='',
                     tipo='revisor',
                 ),
@@ -60,7 +60,7 @@ def app():
                     nome='Pendente',
                     cpf='3',
                     email='pendente@test',
-                    senha=generate_password_hash('123'),
+                    senha=generate_password_hash('123', method="pbkdf2:sha256"),
                     formacao='',
                     tipo='revisor',
                 ),

--- a/tests/test_submission_only.py
+++ b/tests/test_submission_only.py
@@ -49,7 +49,7 @@ def _setup_event(app):
         dia = OficinaDia(oficina_id=oficina.id, data=date.today(), horario_inicio='08:00', horario_fim='10:00')
         db.session.add(dia)
         db.session.commit()
-        user = Usuario(nome='U', cpf='1', email='u@test', senha=generate_password_hash('123'), formacao='x', tipo='participante', cliente_id=cliente.id, evento_id=evento.id, tipo_inscricao_id=tipo.id)
+        user = Usuario(nome='U', cpf='1', email='u@test', senha=generate_password_hash('123', method="pbkdf2:sha256"), formacao='x', tipo='participante', cliente_id=cliente.id, evento_id=evento.id, tipo_inscricao_id=tipo.id)
         db.session.add(user)
         db.session.commit()
         return evento.id, link.token, user.email

--- a/tests/test_submission_reviews.py
+++ b/tests/test_submission_reviews.py
@@ -27,14 +27,14 @@ def app():
             nome='Reviewer',
             cpf='1',
             email='rev@test',
-            senha=generate_password_hash('123'),
+            senha=generate_password_hash('123', method="pbkdf2:sha256"),
             formacao='X',
             tipo='professor',
         )
         sub = Submission(
             title='T',
             locator='loc1',
-            code_hash=generate_password_hash('code'),
+            code_hash=generate_password_hash('code', method="pbkdf2:sha256"),
         )
         db.session.add_all([reviewer, sub])
         db.session.commit()

--- a/tests/test_submission_via_form.py
+++ b/tests/test_submission_via_form.py
@@ -29,7 +29,7 @@ def app():
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
     with app.app_context():
         db.create_all()
-        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('123'))
+        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('123', method="pbkdf2:sha256"))
         db.session.add(cliente)
         db.session.commit()
         evento = Evento(cliente_id=cliente.id, nome='EV', submissao_aberta=True)
@@ -39,7 +39,7 @@ def app():
             nome='Part',
             cpf='1',
             email='part@test',
-            senha=generate_password_hash('123'),
+            senha=generate_password_hash('123', method="pbkdf2:sha256"),
             formacao='x',
             tipo='participante',
             cliente_id=cliente.id,

--- a/tests/test_superadmin_dashboard.py
+++ b/tests/test_superadmin_dashboard.py
@@ -62,11 +62,11 @@ def app():
             nome='Super',
             cpf='1',
             email='super@test',
-            senha=generate_password_hash('123'),
+            senha=generate_password_hash('123', method="pbkdf2:sha256"),
             formacao='X',
             tipo='superadmin'
         )
-        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('456'))
+        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('456', method="pbkdf2:sha256"))
         db.session.add_all([superadmin, cliente])
         db.session.commit()
     yield app

--- a/tests/test_user_deletion_password_reset.py
+++ b/tests/test_user_deletion_password_reset.py
@@ -26,11 +26,11 @@ def app():
         db.create_all()
         admin = Usuario(
             nome='Admin', cpf='admin', email='admin@test',
-            senha=generate_password_hash('123'), formacao='F', tipo='admin'
+            senha=generate_password_hash('123', method="pbkdf2:sha256"), formacao='F', tipo='admin'
         )
         participante = Usuario(
             nome='User', cpf='123', email='user@test',
-            senha=generate_password_hash('123'), formacao='F', tipo='participante'
+            senha=generate_password_hash('123', method="pbkdf2:sha256"), formacao='F', tipo='participante'
         )
         db.session.add_all([admin, participante])
         db.session.commit()

--- a/tests/test_usuario_bloqueio.py
+++ b/tests/test_usuario_bloqueio.py
@@ -21,11 +21,11 @@ def app():
         db.create_all()
         admin = Usuario(
             nome='Admin', cpf='1', email='admin@test',
-            senha=generate_password_hash('123'), formacao='X', tipo='admin'
+            senha=generate_password_hash('123', method="pbkdf2:sha256"), formacao='X', tipo='admin'
         )
         user = Usuario(
             nome='User', cpf='2', email='user@test',
-            senha=generate_password_hash('123'), formacao='Y'
+            senha=generate_password_hash('123', method="pbkdf2:sha256"), formacao='Y'
         )
         db.session.add_all([admin, user])
         db.session.commit()

--- a/tests/test_usuario_cliente_association.py
+++ b/tests/test_usuario_cliente_association.py
@@ -18,9 +18,9 @@ def app():
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
     with app.app_context():
         db.create_all()
-        admin = Usuario(nome='Admin', cpf='0', email='admin@test', senha=generate_password_hash('123'), formacao='X', tipo='admin')
-        c1 = Cliente(nome='C1', email='c1@test', senha=generate_password_hash('123'))
-        c2 = Cliente(nome='C2', email='c2@test', senha=generate_password_hash('123'))
+        admin = Usuario(nome='Admin', cpf='0', email='admin@test', senha=generate_password_hash('123', method="pbkdf2:sha256"), formacao='X', tipo='admin')
+        c1 = Cliente(nome='C1', email='c1@test', senha=generate_password_hash('123', method="pbkdf2:sha256"))
+        c2 = Cliente(nome='C2', email='c2@test', senha=generate_password_hash('123', method="pbkdf2:sha256"))
         db.session.add_all([admin, c1, c2])
         db.session.commit()
         e1 = Evento(cliente_id=c1.id, nome='E1', habilitar_lotes=False, inscricao_gratuita=True)

--- a/tests/test_usuario_registration_multi_event.py
+++ b/tests/test_usuario_registration_multi_event.py
@@ -21,7 +21,7 @@ def app():
     with app.app_context():
         db.create_all()
 
-        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('123'))
+        cliente = Cliente(nome='Cli', email='cli@test', senha=generate_password_hash('123', method="pbkdf2:sha256"))
         db.session.add(cliente)
         db.session.commit()
 
@@ -39,7 +39,7 @@ def app():
             nome='User',
             cpf='111',
             email='user@example.com',
-            senha=generate_password_hash('123'),
+            senha=generate_password_hash('123', method="pbkdf2:sha256"),
             formacao='F',
             tipo='participante',
             cliente_id=cliente.id,

--- a/tests/test_visualizar_agendamento.py
+++ b/tests/test_visualizar_agendamento.py
@@ -118,7 +118,7 @@ def app():
             nome='Admin',
             cpf='1',
             email='admin@test',
-            senha=generate_password_hash('123'),
+            senha=generate_password_hash('123', method="pbkdf2:sha256"),
             formacao='x',
             tipo='admin'
         )


### PR DESCRIPTION
## Summary
- add explicit pbkdf2:sha256 method to all generate_password_hash calls
- document chosen password hash algorithm and length

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: 15 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b08de9d08332a9f7df5fc236768b