### PR TITLE
Increase Gunicorn timeout for long-running tasks

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 
-web: flask --app app db upgrade && gunicorn app:app --worker-class eventlet --workers 4 --timeout 120 --bind 0.0.0.0:$PORT
+web: flask --app app db upgrade && gunicorn app:app --worker-class eventlet --workers 4 --timeout 240 --bind 0.0.0.0:$PORT
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Run the application with Gunicorn using the WSGI entry point from `wsgi.py`. Use
 
 ```
 
-gunicorn app:app --worker-class eventlet --workers 4 --timeout 120 --bind 0.0.0.0:$PORT
+gunicorn app:app --worker-class eventlet --workers 4 --timeout 240 --bind 0.0.0.0:$PORT
 
 ```
 

--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,7 @@ services:
     name: system-web
     env: python
     buildCommand: pip install -r requirements.txt
-    startCommand: flask --app app db upgrade && gunicorn app:app --worker-class eventlet --workers 4 --timeout 120 --bind 0.0.0.0:$PORT
+    startCommand: flask --app app db upgrade && gunicorn app:app --worker-class eventlet --workers 4 --timeout 240 --bind 0.0.0.0:$PORT
     envVars:
       - key: DATABASE_URL
         fromDatabase:


### PR DESCRIPTION
## Summary
- increase Gunicorn timeout to 240s in Procfile and render.yaml
- document longer Gunicorn timeout in README

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: 15 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c70d8d1c8332a62f890b75787486