### PR TITLE
Set Gunicorn timeout to 120 seconds

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 
-web: flask --app app db upgrade && gunicorn app:app --worker-class eventlet --workers 4 --timeout 240 --bind 0.0.0.0:$PORT
+web: flask --app app db upgrade && gunicorn app:app --worker-class eventlet --workers 4 --timeout 120 --bind 0.0.0.0:$PORT
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Run the application with Gunicorn using the WSGI entry point from `wsgi.py`. Use
 
 ```
 
-gunicorn app:app --worker-class eventlet --workers 4 --timeout 240 --bind 0.0.0.0:$PORT
+gunicorn app:app --worker-class eventlet --workers 4 --timeout 120 --bind 0.0.0.0:$PORT
 
 ```
 

--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,7 @@ services:
     name: system-web
     env: python
     buildCommand: pip install -r requirements.txt
-    startCommand: flask --app app db upgrade && gunicorn app:app --worker-class eventlet --workers 4 --timeout 240 --bind 0.0.0.0:$PORT
+    startCommand: flask --app app db upgrade && gunicorn app:app --worker-class eventlet --workers 4 --timeout 120 --bind 0.0.0.0:$PORT
     envVars:
       - key: DATABASE_URL
         fromDatabase:


### PR DESCRIPTION
## Summary
- lower Gunicorn timeout to 120 seconds in deployment configs

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d11f390883329391ba282539df13