### PR TITLE
Ensure reviewer process name persists before database flush

### DIFF
--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -159,11 +159,13 @@ def create_process() -> Any:
         rh.ensure_reviewer_required_fields(created_form)
         dados["formulario_id"] = created_form.id
 
-    processo = RevisorProcess(cliente_id=current_user.id)  # type: ignore[attr-defined]
+    processo = RevisorProcess(
+        cliente_id=current_user.id,  # type: ignore[attr-defined]
+        nome=dados["nome"],
+    )
     db.session.add(processo)
-    db.session.flush()
-
     update_revisor_process(processo, dados)
+    db.session.flush()
     update_process_eventos(processo, dados.get("eventos_ids", []))
     recreate_stages(processo, dados.get("stage_names", []))
     recreate_criterios(processo, dados.get("criterios", []))


### PR DESCRIPTION
## Summary
- Set `nome` on `RevisorProcess` before flushing so inserts include the required field
- Flush session after updating process details, preventing integrity errors

## Testing
- `pytest` *(fails: IndentationError in tests/test_revisor_avaliacao_intervalo.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1536bdbc8332aa8b0f1d9c9bc3a2