### PR TITLE
Use stock status for shopping list filters

### DIFF
--- a/static/js/lista_compras.js
+++ b/static/js/lista_compras.js
@@ -36,14 +36,11 @@ function filtrarMateriais() {
     const incluirEsgotados = document.getElementById('incluir-esgotados').checked;
 
     return materiais.filter(m => {
-        if (m.quantidade_atual < m.quantidade_minima) {
-            if (m.quantidade_atual === 0 && !incluirEsgotados) {
-                return false;
-            }
-            if (m.quantidade_atual > 0 && !incluirBaixa) {
-                return false;
-            }
-            return true;
+        if (m.status_estoque === 'esgotado') {
+            return incluirEsgotados;
+        }
+        if (m.status_estoque === 'baixo') {
+            return incluirBaixa;
         }
         return false;
     });


### PR DESCRIPTION
## Summary
- Filter shopping list materials by `status_estoque` instead of numeric quantities

## Testing
- `python -m pip install -r requirements-dev.txt`
- `pytest` *(fails: IndentationError in tests and 10 errors during collection)*
- Attempted to run server with `SECRET_KEY=dev DB_PASS=postgres GOOGLE_CLIENT_ID=dummy GOOGLE_CLIENT_SECRET=dummy python app.py` *(failed: connection could not be established and multiple missing env variables)*
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68bb51d09a1483328e4bafef59d0eaf9