### PR TITLE
Include professor id in report query

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -689,6 +689,7 @@ def relatorio_geral_agendamentos():
 
     professores_query = (
         db.session.query(
+            Usuario.id.label('id'),
             Usuario.nome.label('nome'),
             Usuario.email.label('email'),
             AgendamentoVisita.responsavel_whatsapp.label(


### PR DESCRIPTION
## Summary
- Ensure `professores_query` selects `Usuario.id` so downstream logic can access `professor.id`
- Cover PDF generation for professor visitor totals with a new test
- Stubbed PDF generation in tests to avoid dependency issues

## Testing
- `pip install -r requirements-dev.txt`
- `pytest tests/test_relatorio_geral_agendamentos.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4'; IndentationError in multiple tests, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bee3d695448332aab6c81a425b971a