### PR TITLE
Ensure default work form exists and add health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,23 @@ Gmail.
 
 `RECAPTCHA_PUBLIC_KEY` e `RECAPTCHA_PRIVATE_KEY` devem conter as chaves obtidas no [Google reCAPTCHA](https://www.google.com/recaptcha/admin). Sem valores válidos, o CAPTCHA não funcionará em produção.
 
+### Formulário de Trabalhos
+
+A aplicação depende de um formulário padrão chamado **Formulário de Trabalhos**.
+Ele é criado automaticamente no início da aplicação, mas você pode verificar
+manualmente sua presença:
+
+```bash
+flask check-formulario-trabalhos
+```
+
+Caso o comando informe que o formulário está ausente, execute o script abaixo
+para criá-lo:
+
+```bash
+python scripts/executar_formulario_trabalhos.py
+```
+
 ## Formulários e processo de revisão
 
 Ao criar um formulário ligado ao processo de revisão, utilize o campo

--- a/app.py
+++ b/app.py
@@ -163,6 +163,25 @@ def create_app():
             "Rotas de diagnóstico de reCAPTCHA desabilitadas"
         )
 
+    # Ensure default submission form exists
+    with app.app_context():
+        from models.formulario import ensure_formulario_trabalhos
+
+        ensure_formulario_trabalhos()
+
+    @app.cli.command("check-formulario-trabalhos")
+    def check_formulario_trabalhos_command() -> None:
+        """Verify the presence of the default submission form."""
+        from models.formulario import formulario_trabalhos_exists
+
+        if formulario_trabalhos_exists():
+            app.logger.info("Formulário de Trabalhos presente.")
+        else:
+            app.logger.error(
+                "Formulário de Trabalhos ausente. Execute "
+                "scripts/executar_formulario_trabalhos.py"
+            )
+
     # Agendamento do reconciliador e rotas utilitárias são registrados aqui
     scheduler = BackgroundScheduler()
     scheduler.add_job(

--- a/models/formulario.py
+++ b/models/formulario.py
@@ -1,0 +1,86 @@
+"""Utilities for default submission form.
+
+This module ensures that the required "Formulário de Trabalhos"
+exists in the database. It exposes helpers used during application
+startup and deployment scripts.
+"""
+
+from __future__ import annotations
+
+from extensions import db
+from models.event import CampoFormulario, Formulario
+
+FORM_NAME = "Formulário de Trabalhos"
+
+
+def formulario_trabalhos_exists() -> bool:
+    """Return True if the default form is present."""
+    return Formulario.query.filter_by(nome=FORM_NAME).first() is not None
+
+
+def ensure_formulario_trabalhos() -> Formulario:
+    """Ensure the default form exists and return it.
+
+    Creates the form with predefined fields when it is missing.
+    """
+    formulario = Formulario.query.filter_by(nome=FORM_NAME).first()
+    if formulario:
+        return formulario
+
+    formulario = Formulario(
+        nome=FORM_NAME,
+        descricao=
+        "Formulário para cadastro de trabalhos acadêmicos pelos clientes",
+        permitir_multiplas_respostas=True,
+        is_submission_form=False,
+    )
+    db.session.add(formulario)
+    db.session.flush()
+
+    campos = [
+        {
+            "nome": "Título",
+            "tipo": "text",
+            "obrigatorio": True,
+            "descricao": "Título do trabalho acadêmico",
+        },
+        {
+            "nome": "Categoria",
+            "tipo": "select",
+            "opcoes": "Prática Educacional,Pesquisa Inovadora,Produto Inovador",
+            "obrigatorio": True,
+            "descricao": "Categoria do trabalho acadêmico",
+        },
+        {
+            "nome": "Rede de Ensino",
+            "tipo": "text",
+            "obrigatorio": True,
+            "descricao": "Rede de ensino onde o trabalho foi desenvolvido",
+        },
+        {
+            "nome": "Etapa de Ensino",
+            "tipo": "text",
+            "obrigatorio": True,
+            "descricao": "Etapa de ensino relacionada ao trabalho",
+        },
+        {
+            "nome": "URL do PDF",
+            "tipo": "url",
+            "obrigatorio": True,
+            "descricao": "URL do arquivo PDF do trabalho",
+        },
+    ]
+    for campo in campos:
+        db.session.add(
+            CampoFormulario(
+                formulario_id=formulario.id,
+                nome=campo["nome"],
+                tipo=campo["tipo"],
+                obrigatorio=campo["obrigatorio"],
+                descricao=campo["descricao"],
+                opcoes=campo.get("opcoes"),
+            )
+        )
+
+    db.session.commit()
+    return formulario

--- a/scripts/executar_formulario_trabalhos.py
+++ b/scripts/executar_formulario_trabalhos.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python3
-"""
-Script para criar o formulário de trabalhos no banco de dados.
-Este script deve ser executado no contexto da aplicação Flask.
-"""
+"""Create the default "Formulário de Trabalhos" if it is missing."""
 
 import sys
 import os
@@ -11,101 +8,16 @@ import os
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from app import create_app
-from extensions import db
-from models.event import Formulario, CampoFormulario
-from sqlalchemy import text
+from models.formulario import ensure_formulario_trabalhos
 
-def criar_formulario_trabalhos():
-    """Cria o formulário de trabalhos e seus campos no banco de dados."""
+
+def main() -> None:
+    """Create the form inside an application context and report its ID."""
     app = create_app()
-    
     with app.app_context():
-        try:
-            # Verificar se o formulário já existe
-            formulario_existente = Formulario.query.filter_by(nome='Formulário de Trabalhos').first()
-            if formulario_existente:
-                print(f"Formulário já existe com ID: {formulario_existente.id}")
-                return formulario_existente.id
-            
-            # Criar o formulário
-            formulario = Formulario(
-                nome='Formulário de Trabalhos',
-                descricao='Formulário para cadastro de trabalhos acadêmicos pelos clientes',
-                permitir_multiplas_respostas=True,
-                is_submission_form=False
-            )
-            
-            db.session.add(formulario)
-            db.session.flush()  # Para obter o ID
-            
-            print(f"Formulário criado com ID: {formulario.id}")
-            
-            # Criar os campos do formulário
-            campos = [
-                {
-                    'nome': 'Título',
-                    'tipo': 'text',
-                    'obrigatorio': True,
-                    'descricao': 'Título do trabalho acadêmico'
-                },
-                {
-                    'nome': 'Categoria',
-                    'tipo': 'select',
-                    'opcoes': 'Prática Educacional,Pesquisa Inovadora,Produto Inovador',
-                    'obrigatorio': True,
-                    'descricao': 'Categoria do trabalho acadêmico'
-                },
-                {
-                    'nome': 'Rede de Ensino',
-                    'tipo': 'text',
-                    'obrigatorio': True,
-                    'descricao': 'Rede de ensino onde o trabalho foi desenvolvido'
-                },
-                {
-                    'nome': 'Etapa de Ensino',
-                    'tipo': 'text',
-                    'obrigatorio': True,
-                    'descricao': 'Etapa de ensino relacionada ao trabalho'
-                },
-                {
-                    'nome': 'URL do PDF',
-                    'tipo': 'url',
-                    'obrigatorio': True,
-                    'descricao': 'URL do arquivo PDF do trabalho'
-                }
-            ]
-            
-            for campo_data in campos:
-                campo = CampoFormulario(
-                    formulario_id=formulario.id,
-                    nome=campo_data['nome'],
-                    tipo=campo_data['tipo'],
-                    obrigatorio=campo_data['obrigatorio'],
-                    descricao=campo_data['descricao'],
-                    opcoes=campo_data.get('opcoes')
-                )
-                db.session.add(campo)
-                print(f"Campo criado: {campo_data['nome']}")
-            
-            # Commit das alterações
-            db.session.commit()
-            print("Formulário de trabalhos criado com sucesso!")
-            
-            # Verificar os campos criados
-            campos_criados = CampoFormulario.query.filter_by(formulario_id=formulario.id).all()
-            print(f"\nCampos criados ({len(campos_criados)}):")
-            for campo in campos_criados:
-                print(f"- {campo.nome} ({campo.tipo}) - Obrigatório: {campo.obrigatorio}")
-                if campo.opcoes:
-                    print(f"  Opções: {campo.opcoes}")
-            
-            return formulario.id
-            
-        except Exception as e:
-            db.session.rollback()
-            print(f"Erro ao criar formulário: {e}")
-            raise
+        formulario = ensure_formulario_trabalhos()
+        print(f"Formulário criado com ID: {formulario.id}")
 
-if __name__ == '__main__':
-    formulario_id = criar_formulario_trabalhos()
-    print(f"\nFormulário criado com ID: {formulario_id}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add utilities to ensure "Formulário de Trabalhos" exists with expected fields
- validate form presence at startup and via new `check-formulario-trabalhos` CLI
- document and expose script to create the form when missing

## Testing
- `python -m pip install -r requirements-dev.txt`
- `pytest` *(fails: unexpected indent and missing modules)*
- `flask --app app check-formulario-trabalhos` *(fails: SECRET_KEY environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_e_68beed4b52908332b6fc9e85f5e6dab9