### PR TITLE
Handle missing trabalhos form gracefully

### DIFF
--- a/routes/trabalho_routes.py
+++ b/routes/trabalho_routes.py
@@ -231,6 +231,13 @@ def meus_trabalhos():
 
 
 # ──────────────────────────── TRABALHOS CLIENTE ─────────────────────────── #
+
+
+def get_trabalhos_form():
+    """Return the 'Formulário de Trabalhos' or ``None`` if absent."""
+    return Formulario.query.filter_by(nome="Formulário de Trabalhos").first()
+
+
 @trabalho_routes.route("/trabalhos")
 @login_required
 def listar_trabalhos():
@@ -238,12 +245,10 @@ def listar_trabalhos():
     if current_user.tipo not in ["cliente", "admin"]:
         flash("Acesso negado.", "danger")
         return redirect(url_for("dashboard_routes.dashboard"))
-    
-    # Buscar formulário de trabalhos
-    formulario = Formulario.query.filter_by(nome='Formulário de Trabalhos').first()
+
+    formulario = get_trabalhos_form()
     if not formulario:
-        flash("Formulário de trabalhos não encontrado.", "danger")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return render_template("trabalhos/formulario_nao_encontrado.html")
     
     # Buscar TODAS as respostas do formulário (não apenas do cliente atual)
     # O cliente precisa ver todos os trabalhos para poder distribuí-los
@@ -304,12 +309,10 @@ def novo_trabalho():
     if current_user.tipo != "cliente":
         flash("Acesso negado.", "danger")
         return redirect(url_for("dashboard_routes.dashboard"))
-    
-    # Buscar formulário de trabalhos
-    formulario = Formulario.query.filter_by(nome='Formulário de Trabalhos').first()
+
+    formulario = get_trabalhos_form()
     if not formulario:
-        flash("Formulário de trabalhos não encontrado.", "danger")
-        return redirect(url_for("dashboard_routes.dashboard"))
+        return render_template("trabalhos/formulario_nao_encontrado.html")
     
     # Buscar eventos disponíveis para o cliente
     eventos = Evento.query.filter_by(cliente_id=current_user.id).all()

--- a/templates/trabalhos/formulario_nao_encontrado.html
+++ b/templates/trabalhos/formulario_nao_encontrado.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block title %}Formulário de Trabalhos Ausente{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <div class="alert alert-warning" role="alert">
+        <h4 class="alert-heading">Formulário não encontrado</h4>
+        <p>O formulário de trabalhos não está configurado.</p>
+        <p class="mb-0">Execute <code>scripts/executar_formulario_trabalhos.py</code> para criar o formulário ou entre em contato com o suporte.</p>
+    </div>
+</div>
+{% endblock %}

--- a/tests/test_trabalhos_form_routes.py
+++ b/tests/test_trabalhos_form_routes.py
@@ -1,0 +1,92 @@
+import os
+import pytest
+from werkzeug.security import generate_password_hash
+
+os.environ.setdefault("SECRET_KEY", "test-key")
+os.environ.setdefault("GOOGLE_CLIENT_ID", "x")
+os.environ.setdefault("GOOGLE_CLIENT_SECRET", "x")
+os.environ.setdefault("DB_PASS", "test")
+
+from config import Config
+
+# Configure in-memory database for tests
+Config.SQLALCHEMY_DATABASE_URI = "sqlite://"
+Config.SQLALCHEMY_ENGINE_OPTIONS = Config.build_engine_options(
+    Config.SQLALCHEMY_DATABASE_URI
+)
+
+from app import create_app
+from extensions import db
+from models.user import Cliente
+from models.event import Evento
+from models.event import Formulario, CampoFormulario
+
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config["TESTING"] = True
+    app.config["WTF_CSRF_ENABLED"] = False
+    with app.app_context():
+        db.create_all()
+        cliente = Cliente(
+            nome="Cli",
+            email="cli@test",
+            senha=generate_password_hash("123", method="pbkdf2:sha256"),
+        )
+        db.session.add(cliente)
+        db.session.commit()
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login(client):
+    return client.post(
+        "/login", data={"email": "cli@test", "senha": "123"}, follow_redirects=False
+    )
+
+
+def test_listar_trabalhos_with_and_without_form(client, app):
+    login(client)
+    resp = client.get("/trabalhos")
+    assert resp.status_code == 200
+    assert b"executar_formulario_trabalhos.py" in resp.data
+
+    with app.app_context():
+        cliente = Cliente.query.filter_by(email="cli@test").first()
+        formulario = Formulario(
+            nome="Formul\u00e1rio de Trabalhos", cliente_id=cliente.id
+        )
+        db.session.add(formulario)
+        db.session.commit()
+
+    resp = client.get("/trabalhos")
+    assert resp.status_code == 200
+    assert b"Meus Trabalhos" in resp.data
+
+
+def test_novo_trabalho_with_and_without_form(client, app):
+    login(client)
+    resp = client.get("/trabalhos/novo")
+    assert resp.status_code == 200
+    assert b"executar_formulario_trabalhos.py" in resp.data
+
+    with app.app_context():
+        cliente = Cliente.query.filter_by(email="cli@test").first()
+        formulario = Formulario(
+            nome="Formul\u00e1rio de Trabalhos", cliente_id=cliente.id
+        )
+        campo = CampoFormulario(
+            formulario_id=formulario.id, nome="Titulo", tipo="text"
+        )
+        evento = Evento(cliente_id=cliente.id, nome="E1")
+        db.session.add_all([formulario, campo, evento])
+        db.session.commit()
+
+    resp = client.get("/trabalhos/novo")
+    assert resp.status_code == 200
+    assert b"Adicionar Novo Trabalho" in resp.data


### PR DESCRIPTION
## Summary
- add `get_trabalhos_form()` helper to centralize form lookup
- show warning template when required form is missing
- cover trabalhos routes with tests for existing/missing form

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: ModuleNotFoundError: No module named 'bs4')*
- `pytest tests/test_trabalhos_form_routes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68beed4d03ac83328349a01def4b5d5e