### PR TITLE
Ensure explicit redirects in client approval route

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -5303,11 +5303,11 @@ def aprovar_agendamento_cliente(agendamento_id):
         db.session.commit()
         NotificacaoAgendamentoService.enviar_email_confirmacao(agendamento)
         flash('Agendamento aprovado com sucesso!', 'success')
+        return redirect(url_for('agendamento_routes.meus_agendamentos_cliente'))
     except Exception as e:
         db.session.rollback()
         flash(f'Erro ao aprovar agendamento: {str(e)}', 'danger')
-
-    return redirect(url_for('agendamento_routes.meus_agendamentos_cliente'))
+        return redirect(url_for('agendamento_routes.meus_agendamentos_cliente'))
 
 
 @agendamento_routes.route('/remover_aluno_cliente/<int:agendamento_id>/<int:aluno_id>', methods=['POST'])


### PR DESCRIPTION
## Summary
- ensure client approval handler returns redirect for success and error

## Testing
- `pytest` *(fails: 10 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c64d9f8d748332b732ff68842a3c93