### PR TITLE
Log agendamento approval errors with generic flash

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -5303,9 +5303,10 @@ def aprovar_agendamento_cliente(agendamento_id):
         db.session.commit()
         NotificacaoAgendamentoService.enviar_email_confirmacao(agendamento)
         flash('Agendamento aprovado com sucesso!', 'success')
-    except Exception as e:
+    except Exception:
         db.session.rollback()
-        flash(f'Erro ao aprovar agendamento: {str(e)}', 'danger')
+        current_app.logger.exception("Erro ao aprovar agendamento")
+        flash('Erro ao aprovar agendamento.', 'danger')
 
     return redirect(url_for('agendamento_routes.meus_agendamentos_cliente'))
 


### PR DESCRIPTION
## Summary
- Log agendamento approval errors using `current_app.logger.exception`
- Replace agendamento approval flash details with a generic message

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: 10 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c64da083f08332ad84a4baa6ba03ad