### PR TITLE
Expose now helper in template context

### DIFF
--- a/tests/test_template_context.py
+++ b/tests/test_template_context.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+import os
+
+os.environ.setdefault("GOOGLE_CLIENT_ID", "x")
+os.environ.setdefault("GOOGLE_CLIENT_SECRET", "x")
+
+from utils import template_context
+
+
+def test_now_available_in_template_context(monkeypatch):
+    class DummyUser:
+        is_authenticated = False
+
+    monkeypatch.setattr(template_context, "current_user", DummyUser())
+    context = template_context.inject_auth_context()
+
+    assert "now" in context
+    assert isinstance(context["now"](), datetime)

--- a/utils/template_context.py
+++ b/utils/template_context.py
@@ -1,4 +1,4 @@
-from flask import g
+from datetime import datetime
 from flask_login import current_user
 from utils.auth import (
     has_permission, 
@@ -22,7 +22,8 @@ def inject_auth_context():
         'is_ministrante': is_ministrante,
         'is_participante': is_participante,
         'can_access_resource': can_access_resource,
-        'current_user_authenticated': current_user.is_authenticated if current_user else False
+        'current_user_authenticated': current_user.is_authenticated if current_user else False,
+        'now': datetime.utcnow
     }
 
 def register_template_context(app):


### PR DESCRIPTION
## Summary
- allow templates to call `now()` by injecting `datetime.utcnow`
- add regression test for new `now` helper

## Testing
- `python -m pip install -r requirements-dev.txt`
- `pytest` *(fails: 10 errors during collection)*
- `pytest tests/test_template_context.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7268356e48332b12fe83bc957bf95