### PR TITLE
Extract cancelation email template

### DIFF
--- a/templates/emails/cancelamento_agendamento.html
+++ b/templates/emails/cancelamento_agendamento.html
@@ -1,10 +1,9 @@
-
-<!-- Template: emails/confirmacao_agendamento.html -->
+<!-- Template: emails/cancelamento_agendamento.html -->
 <!DOCTYPE html>
 <html>
 <head>
     <meta charset="UTF-8">
-    <title>Confirmação de Agendamento</title>
+    <title>Confirmação de Cancelamento</title>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -19,7 +18,7 @@
             border-radius: 5px;
         }
         .header {
-            background-color: #007bff;
+            background-color: #dc3545;
             color: white;
             padding: 10px 20px;
             text-align: center;
@@ -53,33 +52,44 @@
 <body>
     <div class="container">
         <div class="header">
-            <h1>Confirmação de Agendamento</h1>
+            <h1>Confirmação de Cancelamento</h1>
         </div>
         
         <p>Olá, {{ professor.nome }}!</p>
         
-        <p>Seu agendamento para visitação ao evento <strong>{{ evento.nome }}</strong> foi confirmado com sucesso!</p>
+        <p>Seu agendamento para visitação ao evento <strong>{{ evento.nome }}</strong> foi cancelado conforme solicitado.</p>
         
         <div class="info-block">
-            <h3>Detalhes do Agendamento:</h3>
+            <h3>Detalhes do Agendamento Cancelado:</h3>
             <p><strong>Código do Agendamento:</strong> #{{ agendamento.id }}</p>
             <p><strong>Data:</strong> {{ horario.data.strftime('%d/%m/%Y') }}</p>
             <p><strong>Horário:</strong> {{ horario.horario_inicio.strftime('%H:%M') }} às {{ horario.horario_fim.strftime('%H:%M') }}</p>
             <p><strong>Local:</strong> {{ evento.local }}</p>
             <p><strong>Escola:</strong> {{ agendamento.escola_nome }}</p>
             <p><strong>Turma:</strong> {{ agendamento.turma }}</p>
-            <p><strong>Quantidade de Alunos:</strong> {{ agendamento.quantidade_alunos }}</p>
+            <p><strong>Data do Cancelamento:</strong> {{ agendamento.data_cancelamento.strftime('%d/%m/%Y %H:%M') }}</p>
         </div>
         
-        <p>Lembre-se de adicionar a lista de alunos que participarão da visita. Você pode fazer isso acessando o sistema e navegando até "Meus Agendamentos".</p>
+        {% set config = evento.configuracoes_agendamento[0] if evento.configuracoes_agendamento else None %}
+        {% if config %}
+            {% set data_hora_visita = horario.data|string + ' ' + horario.horario_inicio|string %}
+            {% set data_hora_visita = data_hora_visita|to_datetime %}
+            {% set prazo_limite = data_hora_visita - config.prazo_cancelamento|timedelta(hours=true) %}
+            {% set data_cancelamento = agendamento.data_cancelamento %}
+            
+            {% if data_cancelamento > prazo_limite %}
+                <div style="background-color: #f8d7da; border: 1px solid #f5c6cb; color: #721c24; padding: 10px; border-radius: 5px; margin: 15px 0;">
+                    <p><strong>Aviso de Bloqueio:</strong> Seu cancelamento foi realizado fora do prazo estipulado ({{ config.prazo_cancelamento }} horas antes da visita).</p>
+                    <p>De acordo com as regras do evento, você está temporariamente bloqueado para novos agendamentos neste evento por {{ config.tempo_bloqueio }} dias.</p>
+                </div>
+            {% endif %}
+        {% endif %}
         
-        <p>No dia da visita, apresente o QR Code ou o comprovante impresso para agilizar o check-in.</p>
+        <p>Caso queira agendar uma nova visita, você pode fazê-lo através do sistema.</p>
         
         <center>
-            <a href="{{ url_for('agendamento_routes.meus_agendamentos', _external=True) }}" class="btn">Acessar Meus Agendamentos</a>
+            <a href="{{ url_for('routes.eventos_disponiveis_professor', _external=True) }}" class="btn">Ver Eventos Disponíveis</a>
         </center>
-        
-        <p>Se precisar cancelar ou modificar seu agendamento, faça isso com pelo menos {{ evento.configuracoes_agendamento[0].prazo_cancelamento if evento.configuracoes_agendamento else 24 }} horas de antecedência para evitar bloqueios temporários.</p>
         
         <div class="footer">
             <p>Este é um e-mail automático. Por favor, não responda a esta mensagem.</p>

--- a/tests/test_cancelamento_email_template.py
+++ b/tests/test_cancelamento_email_template.py
@@ -1,0 +1,69 @@
+import os
+import flask
+from flask import Flask
+from datetime import datetime, date, time
+from types import SimpleNamespace
+
+os.environ.setdefault("GOOGLE_CLIENT_ID", "test")
+os.environ.setdefault("GOOGLE_CLIENT_SECRET", "test")
+
+from routes import agendamento_routes
+
+
+def test_enviar_email_cancelamento_uses_template(monkeypatch):
+    base_dir = os.path.dirname(os.path.dirname(__file__))
+    app = Flask(__name__, template_folder=os.path.join(base_dir, "templates"))
+
+    professor = SimpleNamespace(nome="Prof", email="prof@example.com")
+    evento = SimpleNamespace(
+        nome="Evento",
+        local="Local",
+        cliente=SimpleNamespace(nome="Cliente"),
+        configuracoes_agendamento=[],
+    )
+    horario = SimpleNamespace(
+        data=date.today(),
+        horario_inicio=time(10, 0),
+        horario_fim=time(11, 0),
+        evento=evento,
+    )
+    agendamento = SimpleNamespace(
+        id=1,
+        professor=professor,
+        horario=horario,
+        evento=evento,
+        escola_nome="Escola",
+        turma="Turma",
+        quantidade_alunos=30,
+        data_cancelamento=datetime.now(),
+    )
+
+    called = {"sent": False}
+
+    def fake_async(*args, **kwargs):
+        called["sent"] = True
+
+    monkeypatch.setattr(
+        agendamento_routes.NotificacaoAgendamentoService,
+        "_enviar_email_async",
+        fake_async,
+    )
+
+    class DummyThread:
+        def __init__(self, target, args):
+            self.target = target
+            self.args = args
+
+        def start(self):
+            self.target(*self.args)
+
+    monkeypatch.setattr(agendamento_routes.threading, "Thread", DummyThread)
+
+    monkeypatch.setattr(flask, "url_for", lambda *args, **kwargs: "http://example.com")
+    app.jinja_env.globals["url_for"] = flask.url_for
+    app.jinja_env.globals["now"] = lambda: datetime.now()
+
+    with app.app_context():
+        agendamento_routes.NotificacaoAgendamentoService.enviar_email_cancelamento(agendamento)
+
+    assert called["sent"]


### PR DESCRIPTION
## Summary
- separate cancellation email into `cancelamento_agendamento.html`
- keep `confirmacao_agendamento.html` focused on confirmation
- add test ensuring cancellation emails render

## Testing
- `pytest` *(fails: TemplateNotFound, ModuleNotFoundError, IndentationError)*
- `pytest tests/test_cancelamento_email_template.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c7268887a48332a0ffc54c9b73151b