### PR TITLE
Ensure confirmation email template uses current year

### DIFF
--- a/routes/agendamento_routes.py
+++ b/routes/agendamento_routes.py
@@ -61,12 +61,12 @@ class NotificacaoAgendamentoService:
     
     @staticmethod
     def enviar_email_confirmacao(agendamento):
-        """
-        Envia email de confirmação para o professor após um agendamento
-        
+        """Envia email de confirmação para o professor após um agendamento.
+
         Args:
             agendamento: Objeto AgendamentoVisita
         """
+        from datetime import datetime
         professor = agendamento.professor
         if professor is None:
             return
@@ -81,7 +81,8 @@ class NotificacaoAgendamentoService:
             professor=professor,
             agendamento=agendamento,
             horario=horario,
-            evento=evento
+            evento=evento,
+            current_year=datetime.utcnow().year,
         )
         
         # Enviar em um thread separado para não bloquear a resposta ao usuário

--- a/templates/emails/confirmacao_agendamento.html
+++ b/templates/emails/confirmacao_agendamento.html
@@ -83,7 +83,7 @@
         
         <div class="footer">
             <p>Este é um e-mail automático. Por favor, não responda a esta mensagem.</p>
-            <p>&copy; {{ now().year }} {{ evento.cliente.nome }} - Todos os direitos reservados.</p>
+            <p>&copy; {{ current_year }} {{ evento.cliente.nome }} - Todos os direitos reservados.</p>
         </div>
     </div>
 </body>


### PR DESCRIPTION
## Summary
- Inject current year into agendamento confirmation email and use it in template

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: 10 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c7268d95688332add5558a9d55be28