### PR TITLE
Support dashboard barema max/min keys

### DIFF
--- a/tests/test_categoria_barema_routes.py
+++ b/tests/test_categoria_barema_routes.py
@@ -120,14 +120,13 @@ def app(monkeypatch):
             categoria="Poster",
             nome="Barema Poster",
             criterios={
-                "clareza": {
-                    "nome": "Clareza",
+                "Clareza": {
                     "descricao": "Avalia clareza da apresentação",
-                    "pontuacao_max": 5,
+                    "max": 5,
                 },
                 "Impacto": {
-                    "pontuacao_min": 2,
-                    "pontuacao_max": 10,
+                    "min": 2,
+                    "max": 10,
                 },
             },
         )

--- a/utils/barema.py
+++ b/utils/barema.py
@@ -26,6 +26,26 @@ def _coerce_number(value: Any, default: float | int | None) -> float | int | Non
     return int(number) if number.is_integer() else number
 
 
+def _extract_numeric(
+    data: Dict[str, Any],
+    keys: tuple[str, ...],
+    default: float | int | None,
+) -> float | int | None:
+    """Return the first numeric value found for ``keys`` in ``data``.
+
+    The helper tries every key using :func:`_coerce_number` with ``None`` as the
+    fallback so that only successfully coerced values are returned. When no
+    value can be coerced the provided ``default`` is returned instead.
+    """
+
+    for key in keys:
+        if key in data:
+            result = _coerce_number(data.get(key), None)
+            if result is not None:
+                return result
+    return default
+
+
 def normalize_barema_requisitos(barema: Any) -> Dict[str, Dict[str, Any]]:
     """Return a normalized ``requisitos`` mapping for any barema instance.
 
@@ -79,12 +99,16 @@ def normalize_barema_requisitos(barema: Any) -> Dict[str, Dict[str, Any]]:
             if isinstance(data, dict):
                 label = data.get("nome") or label
                 descricao = data.get("descricao")
-                max_val = _coerce_number(
-                    data.get("pontuacao_max", data.get("pontuacaoMax")), None
+                max_val = _extract_numeric(
+                    data,
+                    ("max", "pontuacao_max", "pontuacaoMax"),
+                    None,
                 )
-                min_val = _coerce_number(
-                    data.get("pontuacao_min", data.get("pontuacaoMin")), 0
-                ) or 0
+                min_val = _extract_numeric(
+                    data,
+                    ("min", "pontuacao_min", "pontuacaoMin"),
+                    0,
+                )
             else:
                 max_val = _coerce_number(data, None)
             if max_val is None:


### PR DESCRIPTION
## Summary
- allow `normalize_barema_requisitos` to read `max`/`min` alongside legacy fields so dashboard limits persist
- keep the zero default for missing minimum values while normalizing criteria
- cover a barema saved with `max` in the categoria barema route tests

## Testing
- pytest tests/test_categoria_barema_routes.py

------
https://chatgpt.com/codex/tasks/task_e_68cddae2588c8332ab1dc58ed6027651