### PR TITLE
Use assignment form responses when loading category barema

### DIFF
--- a/routes/peer_review_routes.py
+++ b/routes/peer_review_routes.py
@@ -769,24 +769,22 @@ def get_categoria_trabalho_peer_review(submission):
         str: Nome da categoria ou None se não encontrada
     """
     try:
-        # Buscar resposta do formulário relacionada ao trabalho
-        resposta_formulario = RespostaFormulario.query.filter_by(
-            trabalho_id=submission.id,
-            evento_id=submission.evento_id
-        ).first()
-        
-        if not resposta_formulario:
-            return None
-            
-        # Buscar campo "Categoria" nas respostas
-        categoria_resposta = RespostaCampo.query.join(CampoFormulario).filter(
-            RespostaCampo.resposta_formulario_id == resposta_formulario.id,
-            CampoFormulario.nome.ilike('%categoria%')
-        ).first()
-        
+        categoria_resposta = (
+            RespostaCampo.query
+            .join(RespostaFormulario)
+            .join(CampoFormulario)
+            .filter(
+                RespostaFormulario.trabalho_id == submission.id,
+                RespostaFormulario.evento_id == submission.evento_id,
+                CampoFormulario.nome.ilike('%categoria%')
+            )
+            .order_by(RespostaFormulario.id)
+            .first()
+        )
+
         if categoria_resposta and categoria_resposta.valor:
             return categoria_resposta.valor.strip()
-            
+
         return None
     except Exception as e:
         print(f"Erro ao obter categoria do trabalho: {e}")

--- a/routes/revisor_routes.py
+++ b/routes/revisor_routes.py
@@ -1076,9 +1076,15 @@ def avaliar(submission_id: int):
             flash("Acesso negado!", "danger")
             return redirect(url_for(endpoints.DASHBOARD))
 
-    # Buscar a resposta_formulario relacionada ao trabalho
-    resposta_formulario = RespostaFormulario.query.filter_by(trabalho_id=submission.id).first()
-    
+    # Utiliza a resposta associada ao assignment para determinar a categoria
+    resposta_formulario = None
+    if assignment is not None:
+        resposta_formulario = getattr(assignment, "resposta_formulario", None)
+        if resposta_formulario is None and assignment.resposta_formulario_id:
+            resposta_formulario = RespostaFormulario.query.get(
+                assignment.resposta_formulario_id
+            )
+
     # Obter a categoria do trabalho
     categoria_trabalho = None
     if resposta_formulario:
@@ -1346,9 +1352,13 @@ def iniciar_revisao(trabalho_id: int):
         flash("Nenhum revisor atribuído para este trabalho!", "warning")
         return redirect(url_for("evento_routes.home"))
     
-    # Buscar a resposta_formulario relacionada ao trabalho
-    resposta_formulario = RespostaFormulario.query.filter_by(trabalho_id=submission.id).first()
-    
+    # Utiliza a resposta associada ao assignment para determinar a categoria
+    resposta_formulario = getattr(assignment, "resposta_formulario", None)
+    if resposta_formulario is None and assignment.resposta_formulario_id:
+        resposta_formulario = RespostaFormulario.query.get(
+            assignment.resposta_formulario_id
+        )
+
     # Obter a categoria do trabalho
     categoria = None
     if resposta_formulario:


### PR DESCRIPTION
## Summary
- reuse the assignment's linked form response when loading category information in the reviewer evaluation and start-review flows, falling back safely when the relationship is missing
- search across all responses for peer reviews to locate the category answer so the correct barema is chosen even with duplicate form submissions
- extend the categoria barema tests to cover multiple responses per submission and assert the category-specific barema is still applied

## Testing
- pytest tests/test_categoria_barema_routes.py

------
https://chatgpt.com/codex/tasks/task_e_68cddef2c1c08332b2e24e565fd41686