### PR TITLE
Normalize category extraction for reviewer flows

### DIFF
--- a/routes/peer_review_routes.py
+++ b/routes/peer_review_routes.py
@@ -31,8 +31,6 @@ from models import (
     CategoriaBarema,
     EventoBarema,
     RespostaFormulario,
-    RespostaCampo,
-    CampoFormulario,
 )
 
 import uuid
@@ -761,29 +759,30 @@ def create_review():
 # ---------------------------------------------------------------------------
 def get_categoria_trabalho_peer_review(submission):
     """Obtém a categoria do trabalho a partir das respostas do formulário.
-    
+
     Args:
         submission: Objeto Submission
-        
+
     Returns:
         str: Nome da categoria ou None se não encontrada
     """
     try:
-        categoria_resposta = (
-            RespostaCampo.query
-            .join(RespostaFormulario)
-            .join(CampoFormulario)
-            .filter(
-                RespostaFormulario.trabalho_id == submission.id,
-                RespostaFormulario.evento_id == submission.evento_id,
-                CampoFormulario.nome.ilike('%categoria%')
+        from routes.revisor_routes import get_categoria_trabalho
+
+        respostas_formulario = (
+            RespostaFormulario.query
+            .filter_by(
+                trabalho_id=submission.id,
+                evento_id=submission.evento_id,
             )
             .order_by(RespostaFormulario.id)
-            .first()
+            .all()
         )
 
-        if categoria_resposta and categoria_resposta.valor:
-            return categoria_resposta.valor.strip()
+        for resposta_formulario in respostas_formulario:
+            categoria = get_categoria_trabalho(resposta_formulario)
+            if categoria:
+                return categoria
 
         return None
     except Exception as e:

--- a/tests/test_categoria_barema_routes.py
+++ b/tests/test_categoria_barema_routes.py
@@ -79,7 +79,7 @@ def app(monkeypatch):
         )
         campo_categoria = CampoFormulario(
             formulario=formulario,
-            nome="Categoria",
+            nome="Categoria do Trabalho",
             tipo="text",
             obrigatorio=True,
         )
@@ -99,6 +99,13 @@ def app(monkeypatch):
         )
         db.session.add(resposta_sem_categoria)
         db.session.flush()
+
+        resposta_sem_categoria_campo = RespostaCampo(
+            resposta_formulario_id=resposta_sem_categoria.id,
+            campo_id=campo_categoria.id,
+            valor="   ",
+        )
+        db.session.add(resposta_sem_categoria_campo)
 
         resposta = RespostaFormulario(
             formulario_id=formulario.id,
@@ -138,7 +145,12 @@ def app(monkeypatch):
                 },
             },
         )
-        db.session.add_all([resposta_campo, assignment, review, barema])
+        db.session.add_all([
+            resposta_campo,
+            assignment,
+            review,
+            barema,
+        ])
         db.session.flush()
 
         assignment_check = (
@@ -162,16 +174,18 @@ def app(monkeypatch):
 
         globals()["revisor_routes"] = revisor_routes_module
         globals()["peer_review_routes"] = peer_review_routes_module
-        monkeypatch.setattr(
-            peer_review_routes_module,
-            "RespostaCampo",
-            RespostaCampo,
-        )
-        monkeypatch.setattr(
-            peer_review_routes_module,
-            "CampoFormulario",
-            CampoFormulario,
-        )
+        if hasattr(peer_review_routes_module, "RespostaCampo"):
+            monkeypatch.setattr(
+                peer_review_routes_module,
+                "RespostaCampo",
+                RespostaCampo,
+            )
+        if hasattr(peer_review_routes_module, "CampoFormulario"):
+            monkeypatch.setattr(
+                peer_review_routes_module,
+                "CampoFormulario",
+                CampoFormulario,
+            )
 
         class _AssignmentQueryWrapper:
             def __init__(self, query):
@@ -226,11 +240,14 @@ def test_revisor_categoria_barema_get(app):
             .all()
         )
         assert len(respostas) == 2
-        assert respostas[0].respostas_campos == []
+        assert len(respostas[0].respostas_campos) == 1
+        assert respostas[0].respostas_campos[0].valor.strip() == ""
+        assert revisor_routes.get_categoria_trabalho(respostas[0]) is None
         assert any(
-            resposta_campo.campo.nome.lower() == "categoria"
+            "categoria" in resposta_campo.campo.nome.lower()
             for resposta_campo in respostas[1].respostas_campos
         )
+        assert revisor_routes.get_categoria_trabalho(respostas[1]) == "Poster"
 
     with app.test_request_context(f"/revisor/avaliar/{submission.id}", method="GET"):
         login_user(reviewer)


### PR DESCRIPTION
## Summary
- normalize category extraction in the reviewer helper so category matches trim whitespace, parse JSON-like answers, and skip blanks
- reuse the reviewer helper inside the peer review flow to resolve category-specific baremas consistently
- extend the categoria barema tests to cover whitespace answers and fields named "Categoria do Trabalho"

## Testing
- pytest tests/test_categoria_barema_routes.py

------
https://chatgpt.com/codex/tasks/task_e_68cde2a6470483328879a48ca3e99b16