### PR TITLE
Add fallback for reviewer category lookup

### DIFF
--- a/tests/test_categoria_barema_routes.py
+++ b/tests/test_categoria_barema_routes.py
@@ -114,7 +114,7 @@ def app(monkeypatch):
             valor="Poster",
         )
         assignment = Assignment(
-            resposta_formulario_id=resposta.id,
+            resposta_formulario_id=resposta_sem_categoria.id,
             reviewer_id=reviewer.id,
         )
         review = Review(
@@ -225,7 +225,10 @@ def test_revisor_categoria_barema_get(app):
             .order_by(RespostaFormulario.id)
             .all()
         )
+        assignment_db = db.session.query(Assignment).first()
+        assert assignment_db is not None
         assert len(respostas) == 2
+        assert respostas[0].id == assignment_db.resposta_formulario_id
         assert respostas[0].respostas_campos == []
         assert any(
             resposta_campo.campo.nome.lower() == "categoria"


### PR DESCRIPTION
## Summary
- add a helper that parses category answers and falls back to scanning all submission responses when the assignment answer lacks a category
- update the reviewer evaluation and initiation flows to reuse the shared category resolver
- adjust the category barema tests so the assignment points to the answer without the category while verifying the specific barema still renders

## Testing
- pytest tests/test_categoria_barema_routes.py
- pytest *(fails: missing SECRET_KEY and optional test dependencies in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cde2a6fbbc8332ad2e5b0326a56fff